### PR TITLE
better type annotations

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -41,9 +41,32 @@ sphinx:
     - "sphinxcontrib.autodoc_pydantic"
   config:
     #autodoc_typehints: description
+    autodoc_typehints: description
+    autodoc_typehints_format: short
+    python_use_unqualified_type_names: True
     autodoc_type_aliases:
+      "ComponentFactory": "ComponentFactory"
       "ComponentSpec": "ComponentSpec"
-    nb_execution_show_tb: True
+      "CrossSectionFactory": "CrossSectionFactory"
+      "CrossSectionSpec": "CrossSectionSpec"
+      "LayerSpec": "LayerSpec"
+      "LayerSpecs": "LayerSpecs"
+      "Layer": "Layer"
+      "Layers": "Layers"
+      "PathType": "PathType"
+      "SDict": "sax.SDict"
+      "sax.SDict": "sax.SDict"
+      "gdsfactory.typings.ComponentFactory": "ComponentFactory"
+      "gdsfactory.typings.ComponentSpec": "ComponentSpec"
+      "gdsfactory.typings.CrossSectionFactory": "CrossSectionFactory"
+      "gdsfactory.typings.CrossSectionSpec": "CrossSectionSpec"
+      "gdsfactory.typings.LayerSpec": "LayerSpec"
+      "gdsfactory.typings.LayerSpecs": "LayerSpecs"
+      "gdsfactory.typings.Layer": "Layer"
+      "gdsfactory.typings.Layers": "Layers"
+      "gdsfactory.typings.PathType": "PathType"
+      "CrossSection | str | dict[str, Any] | Callable[[...], CrossSection] | SymmetricalCrossSection | DCrossSection": "CrossSectionSpec"
+      "Component | ComponentAllAngle | str | dict[str, Any] | Callable[[...], Component]": "ComponentSpec"
     nb_custom_formats:
       .py:
         - jupytext.reads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=9.12.2"
+  "gdsfactory~=9.14.2"
 ]
 description = "GlobalFoundries 180nm MCU"
 keywords = ["python"]


### PR DESCRIPTION
- **Improve type annotations display in documentation**
- **update gdsfactory**

## Summary by Sourcery

Enhance documentation by improving type annotation display in Sphinx and bump gdsfactory dependency

Build:
- Update gdsfactory dependency to ~9.14.2

Documentation:
- Enhance Sphinx docs to display inline short, unqualified type hints with custom alias mappings and remove notebook traceback display