### PR TITLE
add samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For developers you need to `git clone` the GitHub repository, fork it, git add, 
 ```
 git clone https://github.com/gdsfactory/gf180mcu.git
 cd gf180
-uv venv --python 3.11
+uv venv --python 3.12
 uv sync --extra docs --extra dev
 ```
 

--- a/gf180mcu/samples/all_cells.py
+++ b/gf180mcu/samples/all_cells.py
@@ -1,0 +1,40 @@
+"""This script generates a reticle with all the cells in the library."""
+
+import gdsfactory as gf
+
+from gf180mcu import LAYER, PDK
+
+skip = {
+    "all_cells",
+}
+
+
+@gf.cell
+def all_cells(draw_ports: bool = False) -> gf.Component:
+    """Returns a sample reticle with all cells."""
+    c = gf.Component()
+    cells = []
+
+    for cell_name, cell in PDK.cells.items():
+        try:
+            cell_instance = cell()
+            if draw_ports:
+                cell_instance.draw_ports()
+            cells.append(cell_instance)
+        except Exception as e:
+            print(f"Error instantiating cell {cell_name}: {e}")
+
+    cell_matrix = c << gf.pack(cells)[0]
+    floorplan = c << gf.c.rectangle(
+        size=(cell_matrix.xsize + 20, cell_matrix.ysize + 20),
+        layer=LAYER.border,
+    )
+    floorplan.center = cell_matrix.center
+    return c
+
+
+if __name__ == "__main__":
+    PDK.activate()
+    c = all_cells(draw_ports=True)
+    gdspath = c.write_gds()
+    gf.show(gdspath)


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new sample script to visualize all PDK cells in a single reticle and update the README to require Python 3.12 for the virtual environment

New Features:
- Add a sample script (all_cells.py) that generates a reticle with all cells in the PDK library and optionally draws ports

Documentation:
- Bump the Python version in README setup instructions from 3.11 to 3.12