### PR TITLE
fix docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.gds binary
+*.oas binary

--- a/docs/notebooks/intro.py
+++ b/docs/notebooks/intro.py
@@ -23,8 +23,9 @@
 # You can import the PDK and layout any of the standard cells
 
 # %%
-import gf180mcu  # The new package name (previously gf180)
+from gf180mcu import PDK, cells
 
 # %%
-c = gf180mcu.diode_dw2ps()
+PDK.activate()
+c = cells.diode_dw2ps()
 c.plot()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=9.18.1"
+  "gdsfactory~=9.20.6"
 ]
 description = "GlobalFoundries 180nm MCU"
 keywords = ["python"]


### PR DESCRIPTION
## Summary by Sourcery

Fix documentation notebook to use updated gf180mcu API, bump gdsfactory dependency, and add repository attributes file

Build:
- Bump gdsfactory dependency to version 9.20.6

Documentation:
- Update intro notebook to import PDK and cells from gf180mcu and call PDK.activate() before using cells

Chores:
- Add .gitattributes file to repository