### PR TITLE
add more tests

### DIFF
--- a/.changelog.d/changelog_template.jinja
+++ b/.changelog.d/changelog_template.jinja
@@ -1,0 +1,15 @@
+{% if sections[""] %}
+{% for category, val in definitions.items() if category in sections[""] %}
+
+### {{ definitions[category]['name'] }}
+
+{% for text, values in sections[""][category].items() %}
+- {{ text }} {{ values | join(', ') }}
+{% endfor %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -6,13 +6,6 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-env:
-  GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
-
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -37,19 +30,3 @@ jobs:
         run: uv sync --all-extras
       - name: Run Tests
         run: make test
-  test_gfp:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      max-parallel: 12
-      matrix:
-        python-version: ["3.12"]
-        os: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v7
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Dependencies
-        run: uv sync --all-extras
-      - name: Test with pytest
-        run: uv run gfp test

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -6,6 +6,13 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -30,3 +37,19 @@ jobs:
         run: uv sync --all-extras
       - name: Run Tests
         run: make test
+  test_gfp:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 12
+      matrix:
+        python-version: ["3.12"]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: uv sync --all-extras
+      - name: Test with pytest
+        run: uv run gfp test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # CHANGELOG
+<!-- towncrier release notes start -->
 
 ## 0.4.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dev = [
   "pytest",
   "pytest-cov",
   "pytest_regressions",
-  "pytest-github-actions-annotate-failures"
+  "pytest-github-actions-annotate-failures",
+  "towncrier"
 ]
 docs = ["autodoc_pydantic", "jupytext", "jupyter-book>=0.15.1,<1.1"]
 tests = ["pytest", "pytest-cov"]
@@ -88,6 +89,10 @@ find = {}
 
 [tool.tbump]
 
+[[tool.tbump.before_commit]]
+cmd = "towncrier build --yes --version {new_version}"
+name = "create & check changelog"
+
 [[tool.tbump.file]]
 src = "README.md"
 
@@ -113,3 +118,13 @@ regex = '''
   \.
   (?P<patch>\d+)
   '''
+
+[tool.towncrier]
+directory = ".changelog.d"
+filename = "CHANGELOG.md"
+issue_format = "[#{issue}](https://github.com/gdsfactory/gf180mcu/issues/{issue})"
+package = "gdsfactory"
+start_string = "<!-- towncrier release notes start -->\n"
+template = ".changelog.d/changelog_template.jinja"
+title_format = "## [{version}](https://github.com/gdsfactory/gf180mcu/releases/tag/v{version}) - {project_date}"
+underlines = ["", "", ""]


### PR DESCRIPTION
## Summary by Sourcery

Configure automated changelog generation and GFP tests in CI.

Build:
- Add towncrier as a development dependency and configure it to run automatically before version bumps via tbump.

CI:
- Add workflow-level concurrency control and GFP-specific test job with required API key in the GitHub Actions test workflow.

Documentation:
- Configure towncrier-managed release notes, including a changelog template and marker in CHANGELOG.md for autogenerated entries.