### PR TITLE
add_code_owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @joamatab @sebastian-goeldi @ThomasPluck @kevinwguan


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Introduce initial GitHub CODEOWNERS file to define repository ownership rules