### PR TITLE
add install, pre-commit, and release instructions to README

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,5 +1,4 @@
 name: Auto-label PDK issues
-
 on:
   issues:
     types:
@@ -18,7 +17,6 @@ on:
       - transferred
       - milestoned
       - demilestoned
-
 jobs:
   add-label:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -53,17 +53,17 @@ make pre-commit
 
 ## Release
 
-1. Update the changelog in `.changelog.d/` with entries describing the changes. Make sure the changelog is clear and readable for customers.
-2. Bump the version:
+1. Bump the version:
 
 ```bash
 tbump 0.0.1
 ```
 
-3. Push the tag:
+2. Push the tag:
 
 ```bash
 git push --tags
 ```
+This triggers the release workflow that builds wheels and uploads them.
 
-4. Create a pull request with the updated changelog and version bump. This triggers the release workflow that builds wheels and uploads them.
+3. Create a pull request with the updated changelog since last release.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,17 @@ make pre-commit
 
 ## Release
 
-Releases are automated via GitHub Actions.
+1. Update the changelog in `.changelog.d/` with entries describing the changes. Make sure the changelog is clear and readable for customers.
+2. Bump the version:
 
-1. Merge your changes to `main`.
-2. A draft release is automatically created/updated by the release drafter.
-3. When ready, publish the draft release with a tag (e.g. `v1.0.0`). This triggers the release workflow that builds wheels and uploads them.
+```bash
+tbump 0.0.1
+```
+
+3. Push the tag:
+
+```bash
+git push --tags
+```
+
+4. Create a pull request with the updated changelog and version bump. This triggers the release workflow that builds wheels and uploads them.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,17 @@ uv sync --extra docs --extra dev
 ## Documentation
 
 - [gdsfactory docs](https://gdsfactory.github.io/gdsfactory/)
+
+## Pre-commit
+
+```bash
+make pre-commit
+```
+
+## Release
+
+Releases are automated via GitHub Actions.
+
+1. Merge your changes to `main`.
+2. A draft release is automatically created/updated by the release drafter.
+3. When ready, publish the draft release with a tag (e.g. `v1.0.0`). This triggers the release workflow that builds wheels and uploads them.


### PR DESCRIPTION
## Summary
- Add installation, pre-commit, and release instructions to README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document pre-commit usage and automated release process in the README.

Documentation:
- Add README instructions for running pre-commit checks via make.
- Describe the GitHub Actions–based automated release flow, including draft releases and tagging.