### PR TITLE
Add sheron-lian and thanojo to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @ThomasPluck @kevinwguan
+* @joamatab @ThomasPluck @kevinwguan @sheron-lian @thanojo


### PR DESCRIPTION
## Summary
- Add @sheron-lian and @thanojo as code owners

## Summary by Sourcery

Chores:
- Add sheron-lian and thanojo as code owners in the repository configuration.