### PR TITLE
security: pin runtime and build deps to exact versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=9.39.0",
-  "vlsir>=7.0.0",
-  "vlsirtools>=7.0.0"
+  "gdsfactory==9.39.3",
+  "vlsir==7.0.0",
+  "vlsirtools==7.0.0"
 ]
 description = "GlobalFoundries 180nm MCU"
 keywords = ["python"]


### PR DESCRIPTION
## Summary
- Hard-pin all runtime dependencies and build-system requires to exact versions to mitigate dependency confusion / supply chain attacks
- Dev dependencies left with floor pins (not a runtime attack surface)

## Recommendation
This is a security patch — recommend cutting a new release after merge so downstream consumers pick up the pinned deps.

## Test plan
- [ ] `uv lock` resolves cleanly
- [ ] `uv sync --dev` installs successfully
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)