### PR TITLE
ci(dependabot): switch to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "uv"
+    cooldown:
+      default-days: 7
     directory: "/"
     schedule:
       interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
-      interval: "monthly"
+      interval: monthly
+
   - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
     directory: /
     schedule:
       interval: monthly


### PR DESCRIPTION
Replaces the old pip-based Dependabot config with the centralized template from `doplaydo/pdk-ci-workflow/templates/.github/dependabot.yml`:

- `package-ecosystem: uv` (requires `uv.lock`)
- 7-day cooldown on github-actions updates
- Ignores `doplaydo/*` action updates (managed centrally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch Dependabot to use the uv ecosystem for dependencies and adjust GitHub Actions update behavior.

CI:
- Update Dependabot configuration to use the uv package ecosystem instead of pip for Python dependencies.
- Configure Dependabot GitHub Actions updates with a monthly schedule and a 7-day cooldown between updates.