### PR TITLE
bump gdsfactory to ~=9.40.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 requires = ["flit_core >=3.2,<4"]
 
 [project]
-authors = [{name = "gdsfactory", email = "contact@gdsfactory.com"}]
+authors = [{name = "gdsfactory~=9.40.2", email = "contact@gdsfactory.com"}]
 classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -14,7 +14,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=9.40.0",
+  "gdsfactory~=9.40.2",
   "vlsir>=7.0.0",
   "vlsirtools>=7.0.0"
 ]
@@ -28,7 +28,7 @@ version = "0.5.0"
 
 [project.optional-dependencies]
 dev = [
-  "gdsfactoryplus",
+  "gdsfactory~=9.40.2",
   "pre-commit",
   "pytest",
   "pytest-cov",
@@ -132,7 +132,7 @@ regex = '''
 directory = ".changelog.d"
 filename = "CHANGELOG.md"
 issue_format = "[#{issue}](https://github.com/gdsfactory/gf180mcu/issues/{issue})"
-package = "gdsfactory"
+package = "gdsfactory~=9.40.2"
 start_string = "<!-- towncrier release notes start -->\n"
 template = ".changelog.d/changelog_template.jinja"
 title_format = "## [{version}](https://github.com/gdsfactory/gf180mcu/releases/tag/v{version}) - {project_date}"


### PR DESCRIPTION
## Summary

- Bump gdsfactory from `gdsfactory~=9.40.0` to `~=9.40.2`
- Fixes [gdsfactory/gdsfactory#4485](https://github.com/gdsfactory/gdsfactory/issues/4485): `Pdk.__init__` in 9.40.0 didn't copy `__pydantic_extra__` slot, causing `copy.copy(pdk)` to raise `AttributeError`
- This crashed GF+ server on startup (`get_base_pdk` calls `copy(pdk)`)
- 9.40.1 has the fix, 9.40.2 adds regression test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)