### PR TITLE
bump gdsfactory to <9.40.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=9.40.0",
+  "gdsfactory~=9.40.1",
   "vlsir>=7.0.0",
   "vlsirtools>=7.0.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=9.40.1",
+  "gdsfactory<9.40.2",
   "vlsir>=7.0.0",
   "vlsirtools>=7.0.0"
 ]


### PR DESCRIPTION
## Summary

- Bump gdsfactory to `<9.40.2`
- Fixes [gdsfactory/gdsfactory#4485](https://github.com/gdsfactory/gdsfactory/issues/4485): `Pdk.__init__` in 9.40.0 forgot to copy `__pydantic_extra__` slot, causing `copy.copy(pdk)` to raise `AttributeError`
- This crashed GF+ server on startup (`get_base_pdk` calls `copy(pdk)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)