### PR TITLE
add type tags to all @cell components

### DIFF
--- a/gf180mcu/cells/cap_mim.py
+++ b/gf180mcu/cells/cap_mim.py
@@ -11,7 +11,7 @@ import gdsfactory as gf
 from gf180mcu.layers import layer
 
 
-@gf.cell
+@gf.cell(tags={"type": "cap_mim"})
 def cap_mim(
     mim_option: str = "A",
     metal_level: str = "M4",

--- a/gf180mcu/cells/cap_mim.py
+++ b/gf180mcu/cells/cap_mim.py
@@ -11,7 +11,7 @@ import gdsfactory as gf
 from gf180mcu.layers import layer
 
 
-@gf.cell(tags={"type": "cap_mim"})
+@gf.cell(tags=["cap_mim"])
 def cap_mim(
     mim_option: str = "A",
     metal_level: str = "M4",

--- a/gf180mcu/cells/cap_mos.py
+++ b/gf180mcu/cells/cap_mos.py
@@ -221,7 +221,7 @@ def _guard_ring(c, gx, gy, nwell_x, nwell_y, sub_surround=0.12,
 # Main MOS capacitor generator
 # ---------------------------------------------------------------------------
 
-@gf.cell
+@gf.cell(tags={"type": "cap_mos"})
 def cap_mos(
     type: str = "cap_nmos",
     lc: float = 0.1,

--- a/gf180mcu/cells/cap_mos.py
+++ b/gf180mcu/cells/cap_mos.py
@@ -221,7 +221,7 @@ def _guard_ring(c, gx, gy, nwell_x, nwell_y, sub_surround=0.12,
 # Main MOS capacitor generator
 # ---------------------------------------------------------------------------
 
-@gf.cell(tags={"type": "cap_mos"})
+@gf.cell(tags=["cap_mos"])
 def cap_mos(
     type: str = "cap_nmos",
     lc: float = 0.1,

--- a/gf180mcu/cells/diode.py
+++ b/gf180mcu/cells/diode.py
@@ -297,7 +297,7 @@ def _inner_metal1(c: gf.Component, wa: float, la: float) -> None:
 # diode_nd2ps
 # ---------------------------------------------------------------------------
 
-@gf.cell
+@gf.cell(tags={"type": "diode"})
 def diode_nd2ps(
     la: float = 0.45,
     wa: float = 0.45,
@@ -447,7 +447,7 @@ def diode_nd2ps(
 # diode_pd2nw
 # ---------------------------------------------------------------------------
 
-@gf.cell
+@gf.cell(tags={"type": "diode"})
 def diode_pd2nw(
     la: float = 0.45,
     wa: float = 0.45,
@@ -640,7 +640,7 @@ def diode_pd2nw(
 # diode_nw2ps  (ported from KLayout draw_diode_nw2ps)
 # ---------------------------------------------------------------------------
 
-@gf.cell
+@gf.cell(tags={"type": "diode"})
 def diode_nw2ps(
     la: float = 0.1,
     wa: float = 0.1,
@@ -777,7 +777,7 @@ def diode_nw2ps(
 # diode_pw2dw  (ported from KLayout draw_diode_pw2dw)
 # ---------------------------------------------------------------------------
 
-@gf.cell
+@gf.cell(tags={"type": "diode"})
 def diode_pw2dw(
     la: float = 0.1,
     wa: float = 0.1,
@@ -1085,7 +1085,7 @@ def diode_pw2dw(
 # diode_dw2ps  (ported from KLayout draw_diode_dw2ps)
 # ---------------------------------------------------------------------------
 
-@gf.cell
+@gf.cell(tags={"type": "diode"})
 def diode_dw2ps(
     la: float = 0.1,
     wa: float = 0.1,
@@ -1505,7 +1505,7 @@ def diode_dw2ps(
 # sc_diode  (ported from KLayout draw_sc_diode)
 # ---------------------------------------------------------------------------
 
-@gf.cell
+@gf.cell(tags={"type": "diode"})
 def sc_diode(
     la: float = 0.1,
     wa: float = 0.1,
@@ -1542,7 +1542,7 @@ def sc_diode(
     con_sp = 0.28
     con_comp_enc = 0.07
 
-    @gf.cell
+    @gf.cell(tags={"type": "diode"})
     def sc_cathode_strap(size: Float2 = (0.1, 0.1)) -> gf.Component:
         """Return sc_diode cathode array element."""
         c = gf.Component()
@@ -1572,7 +1572,7 @@ def sc_diode(
 
         return c
 
-    @gf.cell
+    @gf.cell(tags={"type": "diode"})
     def sc_anode_strap(size: Float2 = (0.1, 0.1)) -> gf.Component:
         """Return sc_diode anode array element."""
         c = gf.Component()

--- a/gf180mcu/cells/diode.py
+++ b/gf180mcu/cells/diode.py
@@ -297,7 +297,7 @@ def _inner_metal1(c: gf.Component, wa: float, la: float) -> None:
 # diode_nd2ps
 # ---------------------------------------------------------------------------
 
-@gf.cell(tags={"type": "diode"})
+@gf.cell(tags=["diode"])
 def diode_nd2ps(
     la: float = 0.45,
     wa: float = 0.45,
@@ -447,7 +447,7 @@ def diode_nd2ps(
 # diode_pd2nw
 # ---------------------------------------------------------------------------
 
-@gf.cell(tags={"type": "diode"})
+@gf.cell(tags=["diode"])
 def diode_pd2nw(
     la: float = 0.45,
     wa: float = 0.45,
@@ -640,7 +640,7 @@ def diode_pd2nw(
 # diode_nw2ps  (ported from KLayout draw_diode_nw2ps)
 # ---------------------------------------------------------------------------
 
-@gf.cell(tags={"type": "diode"})
+@gf.cell(tags=["diode"])
 def diode_nw2ps(
     la: float = 0.1,
     wa: float = 0.1,
@@ -777,7 +777,7 @@ def diode_nw2ps(
 # diode_pw2dw  (ported from KLayout draw_diode_pw2dw)
 # ---------------------------------------------------------------------------
 
-@gf.cell(tags={"type": "diode"})
+@gf.cell(tags=["diode"])
 def diode_pw2dw(
     la: float = 0.1,
     wa: float = 0.1,
@@ -1085,7 +1085,7 @@ def diode_pw2dw(
 # diode_dw2ps  (ported from KLayout draw_diode_dw2ps)
 # ---------------------------------------------------------------------------
 
-@gf.cell(tags={"type": "diode"})
+@gf.cell(tags=["diode"])
 def diode_dw2ps(
     la: float = 0.1,
     wa: float = 0.1,
@@ -1505,7 +1505,7 @@ def diode_dw2ps(
 # sc_diode  (ported from KLayout draw_sc_diode)
 # ---------------------------------------------------------------------------
 
-@gf.cell(tags={"type": "diode"})
+@gf.cell(tags=["diode"])
 def sc_diode(
     la: float = 0.1,
     wa: float = 0.1,
@@ -1542,7 +1542,7 @@ def sc_diode(
     con_sp = 0.28
     con_comp_enc = 0.07
 
-    @gf.cell(tags={"type": "diode"})
+    @gf.cell(tags=["diode"])
     def sc_cathode_strap(size: Float2 = (0.1, 0.1)) -> gf.Component:
         """Return sc_diode cathode array element."""
         c = gf.Component()
@@ -1572,7 +1572,7 @@ def sc_diode(
 
         return c
 
-    @gf.cell(tags={"type": "diode"})
+    @gf.cell(tags=["diode"])
     def sc_anode_strap(size: Float2 = (0.1, 0.1)) -> gf.Component:
         """Return sc_diode anode array element."""
         c = gf.Component()

--- a/gf180mcu/cells/fet.py
+++ b/gf180mcu/cells/fet.py
@@ -1080,7 +1080,7 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
 # nfet
 # ---------------------------------------------------------------------------
 
-@gf.cell(tags={"type": "fet"})
+@gf.cell(tags=["fet"])
 def nfet(
     l_gate: float = 0.28,
     w_gate: float = 0.22,
@@ -1120,7 +1120,7 @@ def nfet(
     return c
 
 
-@gf.cell(tags={"type": "fet"})
+@gf.cell(tags=["fet"])
 def pfet(
     l_gate: float = 0.28,
     w_gate: float = 0.22,
@@ -1160,7 +1160,7 @@ def pfet(
     return c
 
 
-@gf.cell(tags={"type": "fet"})
+@gf.cell(tags=["fet"])
 def nfet_06v0_nvt(
     l_gate: float = 1.8,
     w_gate: float = 0.8,

--- a/gf180mcu/cells/fet.py
+++ b/gf180mcu/cells/fet.py
@@ -1080,7 +1080,7 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
 # nfet
 # ---------------------------------------------------------------------------
 
-@gf.cell
+@gf.cell(tags={"type": "fet"})
 def nfet(
     l_gate: float = 0.28,
     w_gate: float = 0.22,
@@ -1120,7 +1120,7 @@ def nfet(
     return c
 
 
-@gf.cell
+@gf.cell(tags={"type": "fet"})
 def pfet(
     l_gate: float = 0.28,
     w_gate: float = 0.22,
@@ -1160,7 +1160,7 @@ def pfet(
     return c
 
 
-@gf.cell
+@gf.cell(tags={"type": "fet"})
 def nfet_06v0_nvt(
     l_gate: float = 1.8,
     w_gate: float = 0.8,

--- a/gf180mcu/cells/guardring.py
+++ b/gf180mcu/cells/guardring.py
@@ -8,7 +8,7 @@ from gf180mcu.layers import LAYER, layer
 dn_rect = partial(gf.components.rectangle, layer=LAYER.dnwell)
 
 
-@gf.cell(tags={"type": "guardring"})
+@gf.cell(tags=["guardring"])
 def pcmpgr_gen(dn_rect=dn_rect, grw: float = 0.36) -> gf.Component:
     """Return deepnwell guardring.
 

--- a/gf180mcu/cells/guardring.py
+++ b/gf180mcu/cells/guardring.py
@@ -8,7 +8,7 @@ from gf180mcu.layers import LAYER, layer
 dn_rect = partial(gf.components.rectangle, layer=LAYER.dnwell)
 
 
-@gf.cell
+@gf.cell(tags={"type": "guardring"})
 def pcmpgr_gen(dn_rect=dn_rect, grw: float = 0.36) -> gf.Component:
     """Return deepnwell guardring.
 

--- a/gf180mcu/cells/res.py
+++ b/gf180mcu/cells/res.py
@@ -1210,7 +1210,7 @@ def _highR_poly_res(
 # ---------------------------------------------------------------------------
 
 
-@gf.cell
+@gf.cell(tags={"type": "res"})
 def res(
     l_res: float = 0.1,
     w_res: float = 0.1,

--- a/gf180mcu/cells/res.py
+++ b/gf180mcu/cells/res.py
@@ -1210,7 +1210,7 @@ def _highR_poly_res(
 # ---------------------------------------------------------------------------
 
 
-@gf.cell(tags={"type": "res"})
+@gf.cell(tags=["res"])
 def res(
     l_res: float = 0.1,
     w_res: float = 0.1,

--- a/gf180mcu/cells/via_generator.py
+++ b/gf180mcu/cells/via_generator.py
@@ -7,7 +7,7 @@ from gdsfactory.typings import Float2, LayerSpec, Size, Spacing
 from gf180mcu.layers import layer
 
 
-@gf.cell
+@gf.cell(tags={"type": "via_generator"})
 def via_generator(
     x_range: Float2 = (0, 1),
     y_range: Float2 = (0, 1),
@@ -83,7 +83,7 @@ def via_generator(
     return c
 
 
-@gf.cell
+@gf.cell(tags={"type": "via_generator"})
 def via_stack(
     x_range: Float2 = (0, 1),
     y_range: Float2 = (0, 1),

--- a/gf180mcu/cells/via_generator.py
+++ b/gf180mcu/cells/via_generator.py
@@ -7,7 +7,7 @@ from gdsfactory.typings import Float2, LayerSpec, Size, Spacing
 from gf180mcu.layers import layer
 
 
-@gf.cell(tags={"type": "via_generator"})
+@gf.cell(tags=["via_generator"])
 def via_generator(
     x_range: Float2 = (0, 1),
     y_range: Float2 = (0, 1),
@@ -83,7 +83,7 @@ def via_generator(
     return c
 
 
-@gf.cell(tags={"type": "via_generator"})
+@gf.cell(tags=["via_generator"])
 def via_stack(
     x_range: Float2 = (0, 1),
     y_range: Float2 = (0, 1),

--- a/gf180mcu/cells/waveguides.py
+++ b/gf180mcu/cells/waveguides.py
@@ -5,7 +5,7 @@ from gdsfactory.cross_section import port_names_electrical, port_types_electrica
 from gdsfactory.typings import CrossSectionSpec, LayerSpec, Size
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def wire_corner(
     cross_section: CrossSectionSpec = "metal2", width: float | None = None
 ) -> gf.Component:
@@ -24,7 +24,7 @@ def wire_corner(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def wire_corner45(
     cross_section: CrossSectionSpec = "metal2",
     radius: float = 10,
@@ -55,7 +55,7 @@ def wire_corner45(
 ####################
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def straight(
     length: float = 10,
     cross_section: CrossSectionSpec = "metal1",
@@ -73,7 +73,7 @@ def straight(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def bend(
     radius: float | None = None,
     angle: float = 90,
@@ -105,7 +105,7 @@ def bend(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def bend_s(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "metal1",

--- a/gf180mcu/cells/waveguides.py
+++ b/gf180mcu/cells/waveguides.py
@@ -5,7 +5,7 @@ from gdsfactory.cross_section import port_names_electrical, port_types_electrica
 from gdsfactory.typings import CrossSectionSpec, LayerSpec, Size
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def wire_corner(
     cross_section: CrossSectionSpec = "metal2", width: float | None = None
 ) -> gf.Component:
@@ -24,7 +24,7 @@ def wire_corner(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def wire_corner45(
     cross_section: CrossSectionSpec = "metal2",
     radius: float = 10,
@@ -55,7 +55,7 @@ def wire_corner45(
 ####################
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def straight(
     length: float = 10,
     cross_section: CrossSectionSpec = "metal1",
@@ -73,7 +73,7 @@ def straight(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def bend(
     radius: float | None = None,
     angle: float = 90,
@@ -105,7 +105,7 @@ def bend(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def bend_s(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "metal1",

--- a/klayout/pymacros/cells/draw_cap_mos.py
+++ b/klayout/pymacros/cells/draw_cap_mos.py
@@ -24,7 +24,7 @@ from .layers_def import layer
 from .via_generator import via_generator, via_stack
 
 
-@gf.cell(tags={"type": "draw_cap_mos"})
+@gf.cell(tags=["draw_cap_mos"])
 def cap_mos_inst(
     lc: float = 0.1,
     wc: float = 0.1,

--- a/klayout/pymacros/cells/draw_cap_mos.py
+++ b/klayout/pymacros/cells/draw_cap_mos.py
@@ -24,7 +24,7 @@ from .layers_def import layer
 from .via_generator import via_generator, via_stack
 
 
-@gf.cell
+@gf.cell(tags={"type": "draw_cap_mos"})
 def cap_mos_inst(
     lc: float = 0.1,
     wc: float = 0.1,

--- a/klayout/pymacros/cells/draw_diode.py
+++ b/klayout/pymacros/cells/draw_diode.py
@@ -1572,7 +1572,7 @@ def draw_sc_diode(
 
     # cathode draw
 
-    @gf.cell
+    @gf.cell(tags={"type": "draw_diode"})
     def sc_cathode_strap(size: Float2 = (0.1, 0.1)) -> gf.Component:
         """Returns sc_diode cathode array element.
 
@@ -1606,7 +1606,7 @@ def draw_sc_diode(
 
         return c
 
-    @gf.cell
+    @gf.cell(tags={"type": "draw_diode"})
     def sc_anode_strap(size: Float2 = (0.1, 0.1)) -> gf.Component:
         """Returns sc_diode anode array element.
 

--- a/klayout/pymacros/cells/draw_diode.py
+++ b/klayout/pymacros/cells/draw_diode.py
@@ -1572,7 +1572,7 @@ def draw_sc_diode(
 
     # cathode draw
 
-    @gf.cell(tags={"type": "draw_diode"})
+    @gf.cell(tags=["draw_diode"])
     def sc_cathode_strap(size: Float2 = (0.1, 0.1)) -> gf.Component:
         """Returns sc_diode cathode array element.
 
@@ -1606,7 +1606,7 @@ def draw_sc_diode(
 
         return c
 
-    @gf.cell(tags={"type": "draw_diode"})
+    @gf.cell(tags=["draw_diode"])
     def sc_anode_strap(size: Float2 = (0.1, 0.1)) -> gf.Component:
         """Returns sc_diode anode array element.
 

--- a/klayout/pymacros/cells/draw_fet.py
+++ b/klayout/pymacros/cells/draw_fet.py
@@ -25,7 +25,7 @@ from .layers_def import layer
 from .via_generator import via_generator, via_stack
 
 
-@gf.cell(tags={"type": "draw_fet"})
+@gf.cell(tags=["draw_fet"])
 def labels_gen(
     label_str: str = "",
     position: Float2 = (0.1, 0.1),
@@ -828,7 +828,7 @@ def bulk_gr_gen(
     # return c
 
 
-@gf.cell(tags={"type": "draw_fet"})
+@gf.cell(tags=["draw_fet"])
 def pcmpgr_gen(dn_rect, grw: float = 0.36) -> gf.Component:
     """Return deepnwell guardring.
 
@@ -995,7 +995,7 @@ def pcmpgr_gen(dn_rect, grw: float = 0.36) -> gf.Component:
     return c
 
 
-@gf.cell(tags={"type": "draw_fet"})
+@gf.cell(tags=["draw_fet"])
 def nfet_deep_nwell(
     volt="3.3V",
     deepnwell: bool = False,
@@ -1751,7 +1751,7 @@ def draw_nfet(
     # return c
 
 
-@gf.cell(tags={"type": "draw_fet"})
+@gf.cell(tags=["draw_fet"])
 def pfet_deep_nwell(
     volt="3.3V",
     deepnwell: bool = False,

--- a/klayout/pymacros/cells/draw_fet.py
+++ b/klayout/pymacros/cells/draw_fet.py
@@ -25,7 +25,7 @@ from .layers_def import layer
 from .via_generator import via_generator, via_stack
 
 
-@gf.cell
+@gf.cell(tags={"type": "draw_fet"})
 def labels_gen(
     label_str: str = "",
     position: Float2 = (0.1, 0.1),
@@ -828,7 +828,7 @@ def bulk_gr_gen(
     # return c
 
 
-@gf.cell
+@gf.cell(tags={"type": "draw_fet"})
 def pcmpgr_gen(dn_rect, grw: float = 0.36) -> gf.Component:
     """Return deepnwell guardring.
 
@@ -995,7 +995,7 @@ def pcmpgr_gen(dn_rect, grw: float = 0.36) -> gf.Component:
     return c
 
 
-@gf.cell
+@gf.cell(tags={"type": "draw_fet"})
 def nfet_deep_nwell(
     volt="3.3V",
     deepnwell: bool = False,
@@ -1751,7 +1751,7 @@ def draw_nfet(
     # return c
 
 
-@gf.cell
+@gf.cell(tags={"type": "draw_fet"})
 def pfet_deep_nwell(
     volt="3.3V",
     deepnwell: bool = False,

--- a/klayout/pymacros/cells/draw_res.py
+++ b/klayout/pymacros/cells/draw_res.py
@@ -95,7 +95,7 @@ def draw_metal_res(
     return layout.cell(cell_name)
 
 
-@gf.cell(tags={"type": "draw_res"})
+@gf.cell(tags=["draw_res"])
 def pcmpgr_gen(dn_rect, grw: float = 0.36) -> gf.Component:
     """Return deepnwell guardring.
 
@@ -262,7 +262,7 @@ def pcmpgr_gen(dn_rect, grw: float = 0.36) -> gf.Component:
     return c
 
 
-@gf.cell(tags={"type": "draw_res"})
+@gf.cell(tags=["draw_res"])
 def plus_res_inst(
     l_res: float = 0.1,
     w_res: float = 0.1,
@@ -553,7 +553,7 @@ def draw_pplus_res(
     return layout.cell(cell_name)
 
 
-@gf.cell(tags={"type": "draw_res"})
+@gf.cell(tags=["draw_res"])
 def polyf_res_inst(
     l_res: float = 0.1,
     w_res: float = 0.1,
@@ -1069,7 +1069,7 @@ def draw_well_res(
     well_rect.dxmin = res_mk.dxmin - nw_res_ext
     well_rect.dymin = res_mk.dymin + nw_res_enc
 
-    @gf.cell(tags={"type": "draw_res"})
+    @gf.cell(tags=["draw_res"])
     def comp_related_gen(size: Float2 = (0.42, 0.42)) -> gf.Component:
         c = gf.Component()
 

--- a/klayout/pymacros/cells/draw_res.py
+++ b/klayout/pymacros/cells/draw_res.py
@@ -95,7 +95,7 @@ def draw_metal_res(
     return layout.cell(cell_name)
 
 
-@gf.cell
+@gf.cell(tags={"type": "draw_res"})
 def pcmpgr_gen(dn_rect, grw: float = 0.36) -> gf.Component:
     """Return deepnwell guardring.
 
@@ -262,7 +262,7 @@ def pcmpgr_gen(dn_rect, grw: float = 0.36) -> gf.Component:
     return c
 
 
-@gf.cell
+@gf.cell(tags={"type": "draw_res"})
 def plus_res_inst(
     l_res: float = 0.1,
     w_res: float = 0.1,
@@ -553,7 +553,7 @@ def draw_pplus_res(
     return layout.cell(cell_name)
 
 
-@gf.cell
+@gf.cell(tags={"type": "draw_res"})
 def polyf_res_inst(
     l_res: float = 0.1,
     w_res: float = 0.1,
@@ -1069,7 +1069,7 @@ def draw_well_res(
     well_rect.dxmin = res_mk.dxmin - nw_res_ext
     well_rect.dymin = res_mk.dymin + nw_res_enc
 
-    @gf.cell
+    @gf.cell(tags={"type": "draw_res"})
     def comp_related_gen(size: Float2 = (0.42, 0.42)) -> gf.Component:
         c = gf.Component()
 

--- a/klayout/pymacros/cells/via_generator.py
+++ b/klayout/pymacros/cells/via_generator.py
@@ -26,7 +26,7 @@ from gdsfactory.typings import Float2, LayerSpec
 from .layers_def import layer
 
 
-@gf.cell(tags={"type": "via_generator"})
+@gf.cell(tags=["via_generator"])
 def via_generator(
     x_range: Float2 = (0, 1),
     y_range: Float2 = (0, 1),
@@ -70,7 +70,7 @@ def via_generator(
     return c
 
 
-@gf.cell(tags={"type": "via_generator"})
+@gf.cell(tags=["via_generator"])
 def via_stack(
     x_range: Float2 = (0, 1),
     y_range: Float2 = (0, 1),

--- a/klayout/pymacros/cells/via_generator.py
+++ b/klayout/pymacros/cells/via_generator.py
@@ -26,7 +26,7 @@ from gdsfactory.typings import Float2, LayerSpec
 from .layers_def import layer
 
 
-@gf.cell
+@gf.cell(tags={"type": "via_generator"})
 def via_generator(
     x_range: Float2 = (0, 1),
     y_range: Float2 = (0, 1),
@@ -70,7 +70,7 @@ def via_generator(
     return c
 
 
-@gf.cell
+@gf.cell(tags={"type": "via_generator"})
 def via_stack(
     x_range: Float2 = (0, 1),
     y_range: Float2 = (0, 1),


### PR DESCRIPTION
## Summary
- Adds `tags={"type": "<filename>"}` to all `@gf.cell` and `@gf.cell_with_module_name` decorators
- Type is derived from the source filename (e.g., `waveguides.py` → `"waveguides"`, `couplers.py` → `"couplers"`)
- Enables filtering and categorization of components by type

Mirrors the change in gdsfactory: https://github.com/gdsfactory/gdsfactory/commit/4c216c5ef

## Test plan
- [ ] Verify all cells still instantiate correctly via `make test`
- [ ] Check that tags appear in cell metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Annotate all @gf.cell components with a type tag derived from their source module (e.g., diode, waveguides, fet, via_generator).