### PR TITLE
Sync .github templates with upstream pdk-ci-workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: "doplaydo/*"
+      - dependency-name: "jupyter-book"
 
   - package-ecosystem: github-actions
     cooldown:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,12 +1,11 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-change-template: '- $TITLE [#$NUMBER](https://github.com/gdsfactory/gf180/pull/$NUMBER)'
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&'
 template: |
   # What's Changed
 
   $CHANGES
-
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 categories:
   - title: 'Breaking'
     label: 'breaking'
@@ -22,10 +21,10 @@ categories:
       - 'github_actions'
   - title: 'Documentation'
     label: 'documentation'
-  - title: 'Other changes'
   - title: 'Dependency Updates'
     label: 'dependencies'
     collapse-after: 5
+
 version-resolver:
   major:
     labels:
@@ -45,8 +44,10 @@ version-resolver:
       - 'dependencies'
       - 'security'
   default: patch
+
 exclude-labels:
   - 'skip-changelog'
+
 autolabeler:
   - label: 'documentation'
     files:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,11 @@
+name: Claude PR Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main
+    secrets: inherit

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -17,6 +17,7 @@ on:
       - transferred
       - milestoned
       - demilestoned
+
 jobs:
   label:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/issue.yml@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+
 jobs:
   docs:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
+    secrets: inherit

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,6 +2,9 @@ name: Release Drafter
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+
 jobs:
   draft:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main
+    secrets: inherit

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -7,5 +7,4 @@ on:
 jobs:
   test:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
-    secrets:
-      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+    secrets: inherit


### PR DESCRIPTION
Syncs workflow templates and config files with the canonical versions from doplaydo/pdk-ci-workflow.

Also fixes CODEOWNERS trailing newline for pre-commit compliance.

## Summary by Sourcery

Sync GitHub workflows and configuration with the upstream pdk-ci-workflow templates and adjust release notes formatting.

Enhancements:
- Update release-drafter configuration to align with upstream formatting and labelling conventions.
- Change GitHub Actions workflows to reuse upstream composite workflows with inherited secrets, including adding a Claude PR review workflow.
- Refine Dependabot configuration to ignore jupyter-book updates alongside doplaydo packages.