### PR TITLE
chore: sync pages.yml + dependabot from upstream template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: "doplaydo/*"
+      # actions/deploy-pages is pinned in templates/.github/workflows/pages.yml
+      # and kept in sync by check_template_drift.py. Bumping it here causes drift
+      # churn — upgrades are owned by the pdk-ci-workflow repo.
+      - dependency-name: "actions/deploy-pages"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,3 +9,17 @@ jobs:
   docs:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
     secrets: inherit
+  deploy-docs:
+    needs: docs
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 install:
+	git submodule update --init --recursive
 	uv sync --extra docs --extra dev
 
 all:

--- a/gf180mcu/__init__.py
+++ b/gf180mcu/__init__.py
@@ -1,7 +1,7 @@
 from gdsfactory.get_factories import get_cells
 from gdsfactory.pdk import Pdk
 
-from gf180mcu import cells, fixed, logic, layers
+from gf180mcu import cells, fixed, layers, logic
 from gf180mcu.config import PATH
 from gf180mcu.layers import (
     LAYER,

--- a/gf180mcu/cells/cap_mim.py
+++ b/gf180mcu/cells/cap_mim.py
@@ -72,7 +72,10 @@ def cap_mim(
     # --- Arm via cluster (contact column to the right) ---
     # arm_nrows: fit via array centered in the arm metal3 region with end_surround+diff_surround enclosure
     m3_arm_enc_y = end_surround + diff_surround  # nominal vertical enclosure (0.375)
-    arm_nrows = floor((lc + 2 * (bot_surround - m3_arm_enc_y - via_size / 2)) / arm_via_pitch) + 1
+    arm_nrows = (
+        floor((lc + 2 * (bot_surround - m3_arm_enc_y - via_size / 2)) / arm_via_pitch)
+        + 1
+    )
     arm_ncols = floor(contact_size / via_size) + 2  # 3 for default params
 
     arm_via_array_w = (arm_ncols - 1) * arm_via_pitch + via_size
@@ -113,15 +116,13 @@ def cap_mim(
     # ---- Draw all layers ----
 
     # Fusetop (cap plate)
-    c.add_ref(
-        gf.components.rectangle(size=(wc, lc), layer=layer["fusetop"])
-    ).move((gx(-hw), gy(-hl)))
+    c.add_ref(gf.components.rectangle(size=(wc, lc), layer=layer["fusetop"])).move(
+        (gx(-hw), gy(-hl))
+    )
 
     # Cap marker (0.2 larger than fusetop on each side)
     c.add_ref(
-        gf.components.rectangle(
-            size=(wc + 0.4, lc + 0.4), layer=layer["cap_mk"]
-        )
+        gf.components.rectangle(size=(wc + 0.4, lc + 0.4), layer=layer["cap_mk"])
     ).move((gx(-hw - 0.2), gy(-hl - 0.2)))
 
     # Metal3 on cap (fusetop shrunk by cap_surround)
@@ -151,21 +152,15 @@ def cap_mim(
     ).move((gx(m2_xmin), gy(m2_ymin)))
     # Left strip (between top and bottom strips, left of fusetop)
     c.add_ref(
-        gf.components.rectangle(
-            size=(-(m2_xmin + hw), lc), layer=bottom_layer
-        )
+        gf.components.rectangle(size=(-(m2_xmin + hw), lc), layer=bottom_layer)
     ).move((gx(m2_xmin), gy(-hl)))
     # Right strip (between top and bottom strips, right of fusetop including arm)
     c.add_ref(
-        gf.components.rectangle(
-            size=(m2_xmax - hw, lc), layer=bottom_layer
-        )
+        gf.components.rectangle(size=(m2_xmax - hw, lc), layer=bottom_layer)
     ).move((gx(hw), gy(-hl)))
 
     # Via2 on cap (left cluster)
-    via_rect = gf.components.rectangle(
-        size=(via_size, via_size), layer=via_layer
-    )
+    via_rect = gf.components.rectangle(size=(via_size, via_size), layer=via_layer)
     c.add_ref(
         via_rect,
         columns=cap_ncols,

--- a/gf180mcu/cells/cap_mos.py
+++ b/gf180mcu/cells/cap_mos.py
@@ -42,38 +42,39 @@ def _snap(v: float) -> float:
 # GDS (CIF) physical constants
 # ---------------------------------------------------------------------------
 
-_CUT     = 0.22    # contact cut size in GDS
-_HCUT    = 0.11    # half contact cut
-_PITCH   = 0.47    # contact pitch (0.22 + 0.25)
-_CIF_DS  = 0.07    # active/poly surround in GDS (painted 0.065 + 0.005 bloat/side)
-_CIF_MS  = 0.06    # metal1 surround in GDS (painted 0.055 + 0.005 bloat/side)
+_CUT = 0.22  # contact cut size in GDS
+_HCUT = 0.11  # half contact cut
+_PITCH = 0.47  # contact pitch (0.22 + 0.25)
+_CIF_DS = 0.07  # active/poly surround in GDS (painted 0.065 + 0.005 bloat/side)
+_CIF_MS = 0.06  # metal1 surround in GDS (painted 0.055 + 0.005 bloat/side)
 
 # Painted constants (used in Magic's geometric formulas)
-_CS   = 0.23    # contact_size
-_DS   = 0.065   # diff/poly surround
-_MS   = 0.055   # metal surround
-_HCS  = 0.115   # contact_size / 2
+_CS = 0.23  # contact_size
+_DS = 0.065  # diff/poly surround
+_MS = 0.055  # metal surround
+_HCS = 0.115  # contact_size / 2
 
 # Geometric constant
-_DIFFT = _CUT + 2 * _CIF_DS   # comp bar thickness (= 0.36)
-_HDIFFT = _DIFFT / 2.0         # = 0.18
+_DIFFT = _CUT + 2 * _CIF_DS  # comp bar thickness (= 0.36)
+_HDIFFT = _DIFFT / 2.0  # = 0.18
 
 # Layer aliases
-_L_COMP     = layer["comp"]
-_L_POLY     = layer["poly2"]
-_L_NPLUS    = layer["nplus"]
-_L_PPLUS    = layer["pplus"]
-_L_CONTACT  = layer["contact"]
-_L_METAL1   = layer["metal1"]
-_L_NWELL    = layer["nwell"]
-_L_LVPWELL  = layer["lvpwell"]
+_L_COMP = layer["comp"]
+_L_POLY = layer["poly2"]
+_L_NPLUS = layer["nplus"]
+_L_PPLUS = layer["pplus"]
+_L_CONTACT = layer["contact"]
+_L_METAL1 = layer["metal1"]
+_L_NWELL = layer["nwell"]
+_L_LVPWELL = layer["lvpwell"]
 _L_DUALGATE = layer["dualgate"]
-_L_MOSCAP   = layer["mos_cap_mk"]
+_L_MOSCAP = layer["mos_cap_mk"]
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _rect(c, x0, y0, x1, y1, lyr) -> None:
     """Add a snapped rectangle."""
@@ -95,8 +96,7 @@ def _contact_array(c, cx, cy, w_env, h_env) -> None:
         for iy in range(ny):
             x = _snap(cx - span_x / 2.0 + ix * _PITCH)
             y = _snap(cy - span_y / 2.0 + iy * _PITCH)
-            _rect(c, x - _CUT / 2, y - _CUT / 2,
-                  x + _CUT / 2, y + _CUT / 2, _L_CONTACT)
+            _rect(c, x - _CUT / 2, y - _CUT / 2, x + _CUT / 2, y + _CUT / 2, _L_CONTACT)
 
 
 # ---------------------------------------------------------------------------
@@ -105,6 +105,7 @@ def _contact_array(c, cx, cy, w_env, h_env) -> None:
 #   orient="vert"  → metal grows N/S (y direction), active/metal width = cs min
 #   orient="horz"  → metal grows E/W (x direction), active/metal height = cs min
 # ---------------------------------------------------------------------------
+
 
 def _draw_contact(c, cx, cy, w, h, active_layer, orient="vert") -> None:
     """Draw a contact with surrounding active region and metal1."""
@@ -117,8 +118,7 @@ def _draw_contact(c, cx, cy, w, h, active_layer, orient="vert") -> None:
     _contact_array(c, cx, cy, cw, ch)
 
     # Active / poly surround
-    _rect(c, cx - hw - _DS, cy - hh - _DS,
-          cx + hw + _DS, cy + hh + _DS, active_layer)
+    _rect(c, cx - hw - _DS, cy - hh - _DS, cx + hw + _DS, cy + hh + _DS, active_layer)
 
     # Metal1 surround (ms applied only along the orientation axis)
     mx0, my0, mx1, my1 = cx - _HCS, cy - _HCS, cx + _HCS, cy + _HCS
@@ -136,8 +136,10 @@ def _draw_contact(c, cx, cy, w, h, active_layer, orient="vert") -> None:
 # Replicates gf180mcu::guard_ring with glc=1, grc=1, gtc=0, gbc=0.
 # ---------------------------------------------------------------------------
 
-def _guard_ring(c, gx, gy, nwell_x, nwell_y, sub_surround=0.12,
-                metal_spacing=0.23, is_6v=False) -> None:
+
+def _guard_ring(
+    c, gx, gy, nwell_x, nwell_y, sub_surround=0.12, metal_spacing=0.23, is_6v=False
+) -> None:
     """Draw the source/drain guard ring (lvpwell ring).
 
     gx, gy        : guard ring size in GDS units (contact-centre to contact-centre).
@@ -147,29 +149,29 @@ def _guard_ring(c, gx, gy, nwell_x, nwell_y, sub_surround=0.12,
     hw = gx / 2.0
     hh = gy / 2.0
 
-    hdiffw = (gx + _DIFFT) / 2.0    # half-width  of top/bottom comp bars
-    hdiffh = (gy + _DIFFT) / 2.0    # half-height of left/right comp bars
+    hdiffw = (gx + _DIFFT) / 2.0  # half-width  of top/bottom comp bars
+    hdiffh = (gy + _DIFFT) / 2.0  # half-height of left/right comp bars
 
     # ---- Comp bars (4 bars forming the ring) ----
-    _rect(c, -hdiffw,  hh - _HDIFFT,  hdiffw,  hh + _HDIFFT, _L_COMP)   # top
-    _rect(c, -hdiffw, -hh - _HDIFFT,  hdiffw, -hh + _HDIFFT, _L_COMP)   # bottom
-    _rect(c,  hw - _HDIFFT, -hdiffh,  hw + _HDIFFT,  hdiffh, _L_COMP)   # right
-    _rect(c, -hw - _HDIFFT, -hdiffh, -hw + _HDIFFT,  hdiffh, _L_COMP)   # left
+    _rect(c, -hdiffw, hh - _HDIFFT, hdiffw, hh + _HDIFFT, _L_COMP)  # top
+    _rect(c, -hdiffw, -hh - _HDIFFT, hdiffw, -hh + _HDIFFT, _L_COMP)  # bottom
+    _rect(c, hw - _HDIFFT, -hdiffh, hw + _HDIFFT, hdiffh, _L_COMP)  # right
+    _rect(c, -hw - _HDIFFT, -hdiffh, -hw + _HDIFFT, hdiffh, _L_COMP)  # left
 
     # ---- Metal1 ring (top, bottom, left, right bars) ----
     hmetw = (gx + _CS) / 2.0
     hmeth = (gy + _CS) / 2.0
-    _rect(c, -hmetw,  hh - _HCS,  hmetw,  hh + _HCS, _L_METAL1)   # top
-    _rect(c, -hmetw, -hh - _HCS,  hmetw, -hh + _HCS, _L_METAL1)   # bottom
-    _rect(c,  hw - _HCS, -hmeth,  hw + _HCS,  hmeth, _L_METAL1)   # right
-    _rect(c, -hw - _HCS, -hmeth, -hw + _HCS,  hmeth, _L_METAL1)   # left
+    _rect(c, -hmetw, hh - _HCS, hmetw, hh + _HCS, _L_METAL1)  # top
+    _rect(c, -hmetw, -hh - _HCS, hmetw, -hh + _HCS, _L_METAL1)  # bottom
+    _rect(c, hw - _HCS, -hmeth, hw + _HCS, hmeth, _L_METAL1)  # right
+    _rect(c, -hw - _HCS, -hmeth, -hw + _HCS, hmeth, _L_METAL1)  # left
 
     # ---- Side contacts (left + right only; glc=grc=1, gtc=gbc=0) ----
     # ch uses CIF metal surround (_CIF_MS) in the painted formula
     ch = gy - _CS - 2 * (_CIF_MS + metal_spacing)
     if ch < _CS:
         ch = _CS
-    _draw_contact(c,  hw, 0, 0, ch, _L_COMP, "vert")
+    _draw_contact(c, hw, 0, 0, ch, _L_COMP, "vert")
     _draw_contact(c, -hw, 0, 0, ch, _L_COMP, "vert")
 
     # ---- lvpwell ring: outer lvpwell rectangle minus nwell inner area ----
@@ -178,20 +180,20 @@ def _guard_ring(c, gx, gy, nwell_x, nwell_y, sub_surround=0.12,
     py_out = hh + _HCUT + _CIF_DS + sub_surround
 
     # Top, bottom, left, right lvpwell bars (ring around nwell)
-    _rect(c, -px_out,  nwell_y,  px_out,  py_out, _L_LVPWELL)   # top
-    _rect(c, -px_out, -py_out,   px_out, -nwell_y, _L_LVPWELL)  # bottom
-    _rect(c, -px_out, -nwell_y, -nwell_x,  nwell_y, _L_LVPWELL) # left
-    _rect(c,  nwell_x, -nwell_y,  px_out,  nwell_y, _L_LVPWELL) # right
+    _rect(c, -px_out, nwell_y, px_out, py_out, _L_LVPWELL)  # top
+    _rect(c, -px_out, -py_out, px_out, -nwell_y, _L_LVPWELL)  # bottom
+    _rect(c, -px_out, -nwell_y, -nwell_x, nwell_y, _L_LVPWELL)  # left
+    _rect(c, nwell_x, -nwell_y, px_out, nwell_y, _L_LVPWELL)  # right
 
     # ---- pplus guard ring implant ----
     # CIF psd → pplus bloat values derived from Magic GDS reference:
     #   outer bars: enc_outer = +0.02 (x), outer strip: enc_outer_x = -0.10
     #   side bars: inner enc = -0.16, outer enc = +0.03
     #   side_by = ch/2 + _DS  (painted diff surround)
-    by_out = hh + _HDIFFT     # outer y of top/bottom comp bars
-    by_in  = hh - _HDIFFT     # inner y of top/bottom comp bars
-    sx_out = hw + _HDIFFT     # outer x of side comp bars
-    sx_in  = hw - _HDIFFT     # inner x of side comp bars
+    by_out = hh + _HDIFFT  # outer y of top/bottom comp bars
+    by_in = hh - _HDIFFT  # inner y of top/bottom comp bars
+    sx_out = hw + _HDIFFT  # outer x of side comp bars
+    sx_in = hw - _HDIFFT  # inner x of side comp bars
 
     side_by = _snap(ch / 2.0 + _DS)
 
@@ -200,26 +202,45 @@ def _guard_ring(c, gx, gy, nwell_x, nwell_y, sub_surround=0.12,
     #   3p3 only: thin outer strip
     # For left/right: 1 rectangle (side bar)
     for sign in (1, -1):
-        s = sign   # +1 for top, -1 for bottom
+        s = sign  # +1 for top, -1 for bottom
         # thin outer strip — 3p3 only (not 6p0)
         if not is_6v:
-            _rect(c, -(hdiffw - 0.10), s * (by_out + 0.02),
-                   (hdiffw - 0.10), s * (by_out + 0.11), _L_PPLUS)
+            _rect(
+                c,
+                -(hdiffw - 0.10),
+                s * (by_out + 0.02),
+                (hdiffw - 0.10),
+                s * (by_out + 0.11),
+                _L_PPLUS,
+            )
         # main body (y: by_in-0.125 to by_out+0.02, wider x)
-        _rect(c, -(hdiffw + 0.02), s * (by_in - 0.125),
-               (hdiffw + 0.02), s * (by_out + 0.02), _L_PPLUS)
+        _rect(
+            c,
+            -(hdiffw + 0.02),
+            s * (by_in - 0.125),
+            (hdiffw + 0.02),
+            s * (by_out + 0.02),
+            _L_PPLUS,
+        )
         # transition strip (y: side_by to by_in-0.125, full x width)
-        _rect(c, -(hdiffw + 0.03), s * side_by,
-               (hdiffw + 0.03), s * (by_in - 0.125), _L_PPLUS)
+        _rect(
+            c,
+            -(hdiffw + 0.03),
+            s * side_by,
+            (hdiffw + 0.03),
+            s * (by_in - 0.125),
+            _L_PPLUS,
+        )
 
     # side bars (left and right)
-    _rect(c,  sx_in - 0.16, -side_by,  sx_out + 0.03,  side_by, _L_PPLUS)   # right
-    _rect(c, -sx_out - 0.03, -side_by, -sx_in + 0.16,  side_by, _L_PPLUS)   # left
+    _rect(c, sx_in - 0.16, -side_by, sx_out + 0.03, side_by, _L_PPLUS)  # right
+    _rect(c, -sx_out - 0.03, -side_by, -sx_in + 0.16, side_by, _L_PPLUS)  # left
 
 
 # ---------------------------------------------------------------------------
 # Main MOS capacitor generator
 # ---------------------------------------------------------------------------
+
 
 @gf.cell(tags=["cap_mos"])
 def cap_mos(
@@ -251,27 +272,27 @@ def cap_mos(
     c = gf.Component()
 
     is_nmos = "cap_nmos" in type
-    is_6v   = volt in ("6.0V", "5/6V", "5.0V")
+    is_6v = volt in ("6.0V", "5/6V", "5.0V")
 
     hl = lc / 2.0
     hw = wc / 2.0
 
     # Voltage-specific Magic ruleset parameters
     if is_6v:
-        diff_spacing    = 0.36
+        diff_spacing = 0.36
         diff_gate_space = 0.30
-        sub_surround    = 0.16
-        metal_spacing   = 0.23
-        dev_sub_dist    = 0.0
+        sub_surround = 0.16
+        metal_spacing = 0.23
+        dev_sub_dist = 0.0
     else:  # 3.3V
-        diff_spacing    = 0.33
+        diff_spacing = 0.33
         diff_gate_space = 0.11
-        sub_surround    = 0.12
-        metal_spacing   = 0.23
-        dev_sub_dist    = 0.12
+        sub_surround = 0.12
+        metal_spacing = 0.23
+        dev_sub_dist = 0.12
 
-    g2d = 0.26   # gate_to_diffcont
-    g2p = 0.28   # gate_to_polycont
+    g2d = 0.26  # gate_to_diffcont
+    g2p = 0.28  # gate_to_polycont
 
     # =========================================================
     # 1. mos_cap_mk marker — exactly lc × wc
@@ -283,7 +304,7 @@ def cap_mos(
     #    poly_ext_y = g2p + HCUT + CIF_DS
     #               = 0.28 + 0.11 + 0.07 = 0.46  (matches reference)
     # =========================================================
-    poly_ext_y = g2p + _HCUT + _CIF_DS   # = 0.46
+    poly_ext_y = g2p + _HCUT + _CIF_DS  # = 0.46
     _rect(c, -hl, -(hw + poly_ext_y), hl, hw + poly_ext_y, _L_POLY)
 
     # =========================================================
@@ -293,28 +314,28 @@ def cap_mos(
     #    3p3: two separate bars flanking the poly gate (comp stops at ±hl)
     #    6p0: one solid rectangle spanning full width (comp covers gate area)
     # =========================================================
-    inner_comp_outer = _snap(hl + g2d + _HCUT + _CIF_DS)   # hl + 0.44
+    inner_comp_outer = _snap(hl + g2d + _HCUT + _CIF_DS)  # hl + 0.44
 
     if is_6v:
         # Solid comp rectangle covering full device width under gate
         _rect(c, -inner_comp_outer, -hw, inner_comp_outer, hw, _L_COMP)
     else:
         # Two separate bars (poly gate separates them)
-        _rect(c,  hl, -hw,  inner_comp_outer, hw, _L_COMP)   # right
-        _rect(c, -inner_comp_outer, -hw, -hl, hw, _L_COMP)   # left
+        _rect(c, hl, -hw, inner_comp_outer, hw, _L_COMP)  # right
+        _rect(c, -inner_comp_outer, -hw, -hl, hw, _L_COMP)  # left
 
     # S/D contacts on inner comp strips
-    cdw = wc - 2 * _DS   # painted contact height
-    _draw_contact(c,  (hl + g2d), 0, 0, cdw, _L_COMP, "vert")
+    cdw = wc - 2 * _DS  # painted contact height
+    _draw_contact(c, (hl + g2d), 0, 0, cdw, _L_COMP, "vert")
     _draw_contact(c, -(hl + g2d), 0, 0, cdw, _L_COMP, "vert")
 
     # =========================================================
     # 4. Poly contacts (top + bottom of gate)
     # =========================================================
-    cpl = lc - 2 * _DS   # poly contact width (painted)
-    pc_y = hw + g2p       # contact centre y
+    cpl = lc - 2 * _DS  # poly contact width (painted)
+    pc_y = hw + g2p  # contact centre y
 
-    _draw_contact(c, 0,  pc_y, cpl, 0, _L_POLY, "horz")
+    _draw_contact(c, 0, pc_y, cpl, 0, _L_POLY, "horz")
     _draw_contact(c, 0, -pc_y, cpl, 0, _L_POLY, "horz")
 
     if label and g_label:
@@ -333,10 +354,10 @@ def cap_mos(
     #    nplus_y_inner= hw + 0.16  (inner y boundary)
     #    nplus_px     = hl + 0.23  (poly gate enc in x)
     # =========================================================
-    nplus_x       = _snap(hl + g2d + _HCUT + 0.23)   # = hl + 0.60
-    nplus_y       = _snap(hw + 0.23)
+    nplus_x = _snap(hl + g2d + _HCUT + 0.23)  # = hl + 0.60
+    nplus_y = _snap(hw + 0.23)
     nplus_y_inner = _snap(hw + 0.16)
-    nplus_px      = _snap(hl + 0.23)                  # = hl + 0.23
+    nplus_px = _snap(hl + 0.23)  # = hl + 0.23
 
     # Main rect (wide, covers S/D regions)
     _rect(c, -nplus_x, -nplus_y_inner, nplus_x, nplus_y_inner, _L_NPLUS)
@@ -379,17 +400,22 @@ def cap_mos(
     else:
         gy = fh + 2 * (diff_gate_space + _DS) + _CS
 
-    _guard_ring(c, gx, gy, nwell_x, nwell_y,
-                sub_surround=sub_surround,
-                metal_spacing=metal_spacing,
-                is_6v=is_6v)
+    _guard_ring(
+        c,
+        gx,
+        gy,
+        nwell_x,
+        nwell_y,
+        sub_surround=sub_surround,
+        metal_spacing=metal_spacing,
+        is_6v=is_6v,
+    )
 
     # =========================================================
     # 8. Dualgate (6.0V only)
     # =========================================================
     if is_6v:
-        _rect(c, -(hl + 1.56), -(hw + 1.52),
-               (hl + 1.56),  (hw + 1.52), _L_DUALGATE)
+        _rect(c, -(hl + 1.56), -(hw + 1.52), (hl + 1.56), (hw + 1.52), _L_DUALGATE)
 
     # =========================================================
     # 9. Ports
@@ -414,8 +440,8 @@ def cap_mos(
     # =========================================================
     # 10. VLSIR metadata
     # =========================================================
-    prefix  = "nmoscap" if is_nmos else "pmoscap"
+    prefix = "nmoscap" if is_nmos else "pmoscap"
     voltage = "3p3" if not is_6v else "6p0"
-    suffix  = "_b" if "_b" in type else ""
+    suffix = "_b" if "_b" in type else ""
 
     return c

--- a/gf180mcu/cells/diode.py
+++ b/gf180mcu/cells/diode.py
@@ -18,21 +18,20 @@ Contact rules:
   Contact inset from guard comp outer: 0.190 (03v3), 0.180 (06v0 or outer guard)
 """
 
-from math import floor
-
 import gdsfactory as gf
-import numpy as np
 from gdsfactory.typings import Float2
 
-from gf180mcu.layers import layer
 from gf180mcu.cells.via_generator import via_generator, via_stack
-
+from gf180mcu.layers import layer
 
 # ---------------------------------------------------------------------------
 # Helper: exact rectangle placement (bypasses gdsfactory snap_to_grid2x)
 # ---------------------------------------------------------------------------
 
-def _add_rect(c: gf.Component, x0: float, y0: float, x1: float, y1: float, lyr: str) -> None:
+
+def _add_rect(
+    c: gf.Component, x0: float, y0: float, x1: float, y1: float, lyr: str
+) -> None:
     """Add an exact rectangle polygon directly, avoiding snap-to-grid rounding."""
     c.add_polygon([(x0, y0), (x0, y1), (x1, y1), (x1, y0)], layer=layer[lyr])
 
@@ -40,6 +39,7 @@ def _add_rect(c: gf.Component, x0: float, y0: float, x1: float, y1: float, lyr: 
 # ---------------------------------------------------------------------------
 # Helper: contact position generation
 # ---------------------------------------------------------------------------
+
 
 def _positions(nc: int, pitch: float) -> list:
     """nc contact centre positions centred on zero."""
@@ -297,6 +297,7 @@ def _inner_metal1(c: gf.Component, wa: float, la: float) -> None:
 # diode_nd2ps
 # ---------------------------------------------------------------------------
 
+
 @gf.cell(tags=["diode"])
 def diode_nd2ps(
     la: float = 0.45,
@@ -327,10 +328,10 @@ def diode_nd2ps(
 
     # Voltage-dependent geometry constants (all from reference GDS analysis)
     if volt == "3.3V":
-        dev_spacing = 0.300   # gap between inner comp and guard ring comp inner edge
-        guard_inner_offset = 0.300   # guard_inner = wa/2 + this
-        guard_outer_offset = 0.680   # guard_outer = wa/2 + this (strip = 0.380)
-        contact_inset = 0.190        # guard contact center to guard comp outer edge
+        dev_spacing = 0.300  # gap between inner comp and guard ring comp inner edge
+        guard_inner_offset = 0.300  # guard_inner = wa/2 + this
+        guard_outer_offset = 0.680  # guard_outer = wa/2 + this (strip = 0.380)
+        contact_inset = 0.190  # guard contact center to guard comp outer edge
         nplus_enc = 0.16
         dg_enc = 0.24
     else:  # 6.0V
@@ -364,22 +365,20 @@ def diode_nd2ps(
 
     # --- Inner device ---
     # Comp
-    c.add_ref(
-        gf.components.rectangle(size=(wa, la), layer=layer["comp"])
-    ).move((-hw, -hl))
+    c.add_ref(gf.components.rectangle(size=(wa, la), layer=layer["comp"])).move(
+        (-hw, -hl)
+    )
 
     # Diode marker
-    c.add_ref(
-        gf.components.rectangle(size=(wa, la), layer=layer["diode_mk"])
-    ).move((-hw, -hl))
+    c.add_ref(gf.components.rectangle(size=(wa, la), layer=layer["diode_mk"])).move(
+        (-hw, -hl)
+    )
 
     # N+ implant (solid rect enclosing inner comp)
     nplus_hw = round(hw + nplus_enc, 4)
     nplus_hl = round(hl + nplus_enc, 4)
     c.add_ref(
-        gf.components.rectangle(
-            size=(2 * nplus_hw, 2 * nplus_hl), layer=layer["nplus"]
-        )
+        gf.components.rectangle(size=(2 * nplus_hw, 2 * nplus_hl), layer=layer["nplus"])
     ).move((-nplus_hw, -nplus_hl))
 
     # Inner contacts
@@ -395,10 +394,14 @@ def diode_nd2ps(
     _guard_ring_comp(c, guard_inner_x, guard_inner_y, guard_outer_x, guard_outer_y)
 
     # P+ implant: ring with notched corners matching Magic VLSI decomposition
-    _pplus_ring(c, guard_inner_x, guard_inner_y, guard_outer_x, guard_outer_y, lyr="pplus")
+    _pplus_ring(
+        c, guard_inner_x, guard_inner_y, guard_outer_x, guard_outer_y, lyr="pplus"
+    )
 
     # Guard ring metal1 (ring: 4 strips)
-    _guard_metal1(c, guard_inner_x, guard_inner_y, guard_outer_x, guard_outer_y, diff_surround)
+    _guard_metal1(
+        c, guard_inner_x, guard_inner_y, guard_outer_x, guard_outer_y, diff_surround
+    )
 
     # Guard ring contacts
     _guard_contacts(c, guard_contact_x, guard_contact_y, nc_gx, nc_gy)
@@ -407,9 +410,7 @@ def diode_nd2ps(
     lvp_hx = round(guard_outer_x + lvpwell_enc, 4)
     lvp_hy = round(guard_outer_y + lvpwell_enc, 4)
     c.add_ref(
-        gf.components.rectangle(
-            size=(2 * lvp_hx, 2 * lvp_hy), layer=layer["lvpwell"]
-        )
+        gf.components.rectangle(size=(2 * lvp_hx, 2 * lvp_hy), layer=layer["lvpwell"])
     ).move((-lvp_hx, -lvp_hy))
 
     # Dualgate for 6.0V
@@ -447,6 +448,7 @@ def diode_nd2ps(
 # diode_pd2nw
 # ---------------------------------------------------------------------------
 
+
 @gf.cell(tags=["diode"])
 def diode_pd2nw(
     la: float = 0.45,
@@ -477,16 +479,16 @@ def diode_pd2nw(
 
     if volt == "3.3V":
         # Inner guard ring
-        ig_inner_offset = 0.300   # guard_inner = wa/2 + this
-        ig_outer_offset = 0.680   # guard_outer = wa/2 + this
+        ig_inner_offset = 0.300  # guard_inner = wa/2 + this
+        ig_outer_offset = 0.680  # guard_outer = wa/2 + this
         ig_contact_inset = 0.190
         nw_enc = 0.12
-        nplus_enc_out = 0.16     # nplus outer enc on ig_outer
-        nplus_enc_in = 0.090     # nplus inner enc on ig_inner (inward)
+        nplus_enc_out = 0.16  # nplus outer enc on ig_outer
+        nplus_enc_in = 0.090  # nplus inner enc on ig_inner (inward)
         lvpwell_enc = 0.12
         # Outer guard ring (relative to inner guard outer)
-        og_inner_gap = 0.450     # outer_guard_inner = inner_guard_outer + this
-        og_strip = 0.360         # outer_guard_outer = outer_guard_inner + this
+        og_inner_gap = 0.450  # outer_guard_inner = inner_guard_outer + this
+        og_strip = 0.360  # outer_guard_outer = outer_guard_inner + this
         # outer_guard_outer = inner_guard_outer + 0.450 + 0.360 = inner_guard_outer + 0.810
         og_contact_inset = 0.180
         dg_enc = 0.24
@@ -496,7 +498,7 @@ def diode_pd2nw(
         ig_contact_inset = 0.180
         nw_enc = 0.16
         nplus_enc_out = 0.16
-        nplus_enc_in = 0.070     # nplus inner enc (inward) for 6.0V
+        nplus_enc_in = 0.070  # nplus inner enc (inward) for 6.0V
         lvpwell_enc = 0.16
         og_inner_gap = 0.520
         og_strip = 0.360
@@ -534,21 +536,19 @@ def diode_pd2nw(
     nc_outer_side_y = _nc_outer_guard_side(og_inner_y)
 
     # --- Inner device (P+ diffusion) ---
-    c.add_ref(
-        gf.components.rectangle(size=(wa, la), layer=layer["comp"])
-    ).move((-hw, -hl))
+    c.add_ref(gf.components.rectangle(size=(wa, la), layer=layer["comp"])).move(
+        (-hw, -hl)
+    )
 
-    c.add_ref(
-        gf.components.rectangle(size=(wa, la), layer=layer["diode_mk"])
-    ).move((-hw, -hl))
+    c.add_ref(gf.components.rectangle(size=(wa, la), layer=layer["diode_mk"])).move(
+        (-hw, -hl)
+    )
 
     # P+ implant on inner device
     pplus_hw = round(hw + 0.16, 4)
     pplus_hl = round(hl + 0.16, 4)
     c.add_ref(
-        gf.components.rectangle(
-            size=(2 * pplus_hw, 2 * pplus_hl), layer=layer["pplus"]
-        )
+        gf.components.rectangle(size=(2 * pplus_hw, 2 * pplus_hl), layer=layer["pplus"])
     ).move((-pplus_hw, -pplus_hl))
 
     # Inner contacts
@@ -579,9 +579,7 @@ def diode_pd2nw(
     nw_hx = round(ig_outer_x + nw_enc, 4)
     nw_hy = round(ig_outer_y + nw_enc, 4)
     c.add_ref(
-        gf.components.rectangle(
-            size=(2 * nw_hx, 2 * nw_hy), layer=layer["nwell"]
-        )
+        gf.components.rectangle(size=(2 * nw_hx, 2 * nw_hy), layer=layer["nwell"])
     ).move((-nw_hx, -nw_hy))
 
     # --- Outer guard ring (P+ comp = LVPWELL ground) ---
@@ -603,7 +601,9 @@ def diode_pd2nw(
     lvp_outer_y = round(og_outer_y + lvpwell_enc, 4)
     lvp_inner_x = round(nw_hx, 4)
     lvp_inner_y = round(nw_hy, 4)
-    _guard_ring_comp(c, lvp_inner_x, lvp_inner_y, lvp_outer_x, lvp_outer_y, lyr="lvpwell")
+    _guard_ring_comp(
+        c, lvp_inner_x, lvp_inner_y, lvp_outer_x, lvp_outer_y, lyr="lvpwell"
+    )
 
     # Dualgate for 6.0V
     if volt == "6.0V":
@@ -639,6 +639,7 @@ def diode_pd2nw(
 # ---------------------------------------------------------------------------
 # diode_nw2ps  (ported from KLayout draw_diode_nw2ps)
 # ---------------------------------------------------------------------------
+
 
 @gf.cell(tags=["diode"])
 def diode_nw2ps(
@@ -776,6 +777,7 @@ def diode_nw2ps(
 # ---------------------------------------------------------------------------
 # diode_pw2dw  (ported from KLayout draw_diode_pw2dw)
 # ---------------------------------------------------------------------------
+
 
 @gf.cell(tags=["diode"])
 def diode_pw2dw(
@@ -1084,6 +1086,7 @@ def diode_pw2dw(
 # ---------------------------------------------------------------------------
 # diode_dw2ps  (ported from KLayout draw_diode_dw2ps)
 # ---------------------------------------------------------------------------
+
 
 @gf.cell(tags=["diode"])
 def diode_dw2ps(
@@ -1504,6 +1507,7 @@ def diode_dw2ps(
 # ---------------------------------------------------------------------------
 # sc_diode  (ported from KLayout draw_sc_diode)
 # ---------------------------------------------------------------------------
+
 
 @gf.cell(tags=["diode"])
 def sc_diode(

--- a/gf180mcu/cells/fet.py
+++ b/gf180mcu/cells/fet.py
@@ -64,12 +64,12 @@ _RULES = dict(
 )
 
 # Physical GDS dimensions (after CIF conversion)
-_CIF_CONTACT_CUT = 0.22         # contact cut on GDS layer 33
-_CIF_DIFF_SURROUND = 0.07       # active/poly surround in GDS
-_CIF_POLY_SURROUND = 0.07       # poly surround in GDS
-_CIF_METAL_SURROUND = 0.06      # metal1 surround in GDS
-_CIF_CONTACT_GAP = 0.25         # min gap between contact cuts
-_CIF_CONTACT_PITCH = 0.47       # _CIF_CONTACT_CUT + _CIF_CONTACT_GAP
+_CIF_CONTACT_CUT = 0.22  # contact cut on GDS layer 33
+_CIF_DIFF_SURROUND = 0.07  # active/poly surround in GDS
+_CIF_POLY_SURROUND = 0.07  # poly surround in GDS
+_CIF_METAL_SURROUND = 0.06  # metal1 surround in GDS
+_CIF_CONTACT_GAP = 0.25  # min gap between contact cuts
+_CIF_CONTACT_PITCH = 0.47  # _CIF_CONTACT_CUT + _CIF_CONTACT_GAP
 
 # Layer aliases
 _L_COMP = layer["comp"]
@@ -94,6 +94,7 @@ _L_PR_BNDRY = layer["pr_bndry"]
 # Helper: add a snapped rectangle
 # ---------------------------------------------------------------------------
 
+
 def _rect(c, x0, y0, x1, y1, layer_spec):
     x0, y0, x1, y1 = _snap(x0), _snap(y0), _snap(x1), _snap(y1)
     if abs(x1 - x0) < 1e-6 or abs(y1 - y0) < 1e-6:
@@ -104,6 +105,7 @@ def _rect(c, x0, y0, x1, y1, layer_spec):
 # ---------------------------------------------------------------------------
 # Contact cut array — places 0.22 x 0.22 cuts with 0.47 pitch
 # ---------------------------------------------------------------------------
+
 
 def _contact_cuts(c, cx, cy, w_envelope, h_envelope):
     """Place contact cuts within an envelope of size (w_envelope, h_envelope)
@@ -144,16 +146,15 @@ def _contact_cuts(c, cx, cy, w_envelope, h_envelope):
         for iy in range(ny):
             x = _snap(cx - span_x / 2.0 + ix * pitch)
             y = _snap(cy - span_y / 2.0 + iy * pitch)
-            _rect(c, x - cut / 2, y - cut / 2,
-                  x + cut / 2, y + cut / 2, _L_CONTACT)
+            _rect(c, x - cut / 2, y - cut / 2, x + cut / 2, y + cut / 2, _L_CONTACT)
 
 
 # ---------------------------------------------------------------------------
 # draw_contact — replicates gf180mcu::draw_contact
 # ---------------------------------------------------------------------------
 
-def _draw_contact(c, cx, cy, w, h, rules, active_layer, orient="vert",
-                   no_cuts=False):
+
+def _draw_contact(c, cx, cy, w, h, rules, active_layer, orient="vert", no_cuts=False):
     """Draw contact with surrounding active/poly and metal1.
 
     w, h: requested contact area size (painted dimensions).
@@ -206,8 +207,19 @@ def _draw_contact(c, cx, cy, w, h, rules, active_layer, orient="vert",
 # Guard ring — replicates gf180mcu::guard_ring
 # ---------------------------------------------------------------------------
 
-def _guard_ring(c, gx, gy, rules, sub_layer, full_metal=True,
-                glc=True, grc=True, gtc=False, gbc=False):
+
+def _guard_ring(
+    c,
+    gx,
+    gy,
+    rules,
+    sub_layer,
+    full_metal=True,
+    glc=True,
+    grc=True,
+    gtc=False,
+    gbc=False,
+):
     """Draw guard ring centered at origin.
 
     gx, gy: guard ring size measured to contact centers (painted coords).
@@ -228,19 +240,19 @@ def _guard_ring(c, gx, gy, rules, sub_layer, full_metal=True,
     hdiffh = (gy + difft) / 2.0
 
     # Guard ring diffusion (comp layer) — 4 bars forming a ring
-    _rect(c, -hdiffw, hh - hdifft, hdiffw, hh + hdifft, _L_COMP)    # top
+    _rect(c, -hdiffw, hh - hdifft, hdiffw, hh + hdifft, _L_COMP)  # top
     _rect(c, -hdiffw, -hh - hdifft, hdiffw, -hh + hdifft, _L_COMP)  # bottom
-    _rect(c, hw - hdifft, -hdiffh, hw + hdifft, hdiffh, _L_COMP)    # right
+    _rect(c, hw - hdifft, -hdiffh, hw + hdifft, hdiffh, _L_COMP)  # right
     _rect(c, -hw - hdifft, -hdiffh, -hw + hdifft, hdiffh, _L_COMP)  # left
 
     # Full metal ring
     if full_metal:
         hmetw = (gx + contact_size) / 2.0
         hmeth = (gy + contact_size) / 2.0
-        _rect(c, -hmetw, hh - hx, hmetw, hh + hx, _L_METAL1)      # top
-        _rect(c, -hmetw, -hh - hx, hmetw, -hh + hx, _L_METAL1)    # bottom
-        _rect(c, hw - hx, -hmeth, hw + hx, hmeth, _L_METAL1)       # right
-        _rect(c, -hw - hx, -hmeth, -hw + hx, hmeth, _L_METAL1)     # left
+        _rect(c, -hmetw, hh - hx, hmetw, hh + hx, _L_METAL1)  # top
+        _rect(c, -hmetw, -hh - hx, hmetw, -hh + hx, _L_METAL1)  # bottom
+        _rect(c, hw - hx, -hmeth, hw + hx, hmeth, _L_METAL1)  # right
+        _rect(c, -hw - hx, -hmeth, -hw + hx, hmeth, _L_METAL1)  # left
 
     # Contact height/width for side/top-bottom contacts
     ch = gy - contact_size - 2 * (metal_surround + metal_spacing)
@@ -262,8 +274,7 @@ def _guard_ring(c, gx, gy, rules, sub_layer, full_metal=True,
 
     # Substrate/well layer
     sub_ext = hx + diff_surround + sub_surround
-    _rect(c, -hw - sub_ext, -hh - sub_ext,
-          hw + sub_ext, hh + sub_ext, sub_layer)
+    _rect(c, -hw - sub_ext, -hh - sub_ext, hw + sub_ext, hh + sub_ext, sub_layer)
 
     return (-hw - sub_ext, -hh - sub_ext, hw + sub_ext, hh + sub_ext)
 
@@ -271,6 +282,7 @@ def _guard_ring(c, gx, gy, rules, sub_layer, full_metal=True,
 # ---------------------------------------------------------------------------
 # Guard ring implant
 # ---------------------------------------------------------------------------
+
 
 def _guard_ring_implant(c, gx, gy, implant_layer, rules):
     """Draw implant for the guard ring.
@@ -314,34 +326,82 @@ def _guard_ring_implant(c, gx, gy, implant_layer, rules):
 
     if implant_layer == _L_PPLUS:
         # NFET guard ring: pplus with small CIF bloat (~0.02-0.03)
-        enc_tb = 0.02   # top/bottom bar bloat
+        enc_tb = 0.02  # top/bottom bar bloat
         enc_side_x = 0.03  # side bar X bloat
 
         # Top bar
-        _rect(c, -bar_outer_x - enc_tb, bar_inner_y - enc_tb,
-              bar_outer_x + enc_tb, bar_outer_y + enc_tb, implant_layer)
+        _rect(
+            c,
+            -bar_outer_x - enc_tb,
+            bar_inner_y - enc_tb,
+            bar_outer_x + enc_tb,
+            bar_outer_y + enc_tb,
+            implant_layer,
+        )
         # Bottom bar
-        _rect(c, -bar_outer_x - enc_tb, -bar_outer_y - enc_tb,
-              bar_outer_x + enc_tb, -bar_inner_y + enc_tb, implant_layer)
+        _rect(
+            c,
+            -bar_outer_x - enc_tb,
+            -bar_outer_y - enc_tb,
+            bar_outer_x + enc_tb,
+            -bar_inner_y + enc_tb,
+            implant_layer,
+        )
         # Left side bar (main body)
-        _rect(c, -side_outer_x - enc_side_x, -side_impl_half_y,
-              -side_inner_x + enc_side_x, side_impl_half_y, implant_layer)
+        _rect(
+            c,
+            -side_outer_x - enc_side_x,
+            -side_impl_half_y,
+            -side_inner_x + enc_side_x,
+            side_impl_half_y,
+            implant_layer,
+        )
         # Right side bar (main body)
-        _rect(c, side_inner_x - enc_side_x, -side_impl_half_y,
-              side_outer_x + enc_side_x, side_impl_half_y, implant_layer)
+        _rect(
+            c,
+            side_inner_x - enc_side_x,
+            -side_impl_half_y,
+            side_outer_x + enc_side_x,
+            side_impl_half_y,
+            implant_layer,
+        )
         # Corner pieces (bridge between bars and side bars)
         # Top-left corner
-        _rect(c, -bar_outer_x - enc_tb, side_impl_half_y,
-              -side_inner_x + enc_side_x, bar_inner_y - enc_tb, implant_layer)
+        _rect(
+            c,
+            -bar_outer_x - enc_tb,
+            side_impl_half_y,
+            -side_inner_x + enc_side_x,
+            bar_inner_y - enc_tb,
+            implant_layer,
+        )
         # Top-right corner
-        _rect(c, side_inner_x - enc_side_x, side_impl_half_y,
-              bar_outer_x + enc_tb, bar_inner_y - enc_tb, implant_layer)
+        _rect(
+            c,
+            side_inner_x - enc_side_x,
+            side_impl_half_y,
+            bar_outer_x + enc_tb,
+            bar_inner_y - enc_tb,
+            implant_layer,
+        )
         # Bottom-left corner
-        _rect(c, -bar_outer_x - enc_tb, -bar_inner_y + enc_tb,
-              -side_inner_x + enc_side_x, -side_impl_half_y, implant_layer)
+        _rect(
+            c,
+            -bar_outer_x - enc_tb,
+            -bar_inner_y + enc_tb,
+            -side_inner_x + enc_side_x,
+            -side_impl_half_y,
+            implant_layer,
+        )
         # Bottom-right corner
-        _rect(c, side_inner_x - enc_side_x, -bar_inner_y + enc_tb,
-              bar_outer_x + enc_tb, -side_impl_half_y, implant_layer)
+        _rect(
+            c,
+            side_inner_x - enc_side_x,
+            -bar_inner_y + enc_tb,
+            bar_outer_x + enc_tb,
+            -side_impl_half_y,
+            implant_layer,
+        )
 
     else:
         # PFET guard ring: nplus with outer bloat 0.16, inner bloat varies
@@ -355,28 +415,40 @@ def _guard_ring_implant(c, gx, gy, implant_layer, rules):
 
         # Inner boundary of the nplus ring
         inner_x = _snap(side_inner_x - enc_in)  # inner X
-        inner_y = _snap(bar_inner_y - enc_in)    # inner Y
+        inner_y = _snap(bar_inner_y - enc_in)  # inner Y
 
         # Top bar (full width, from inner_y to outer top)
-        _rect(c, -bar_outer_x - enc_out, inner_y,
-              bar_outer_x + enc_out, bar_outer_y + enc_out, implant_layer)
+        _rect(
+            c,
+            -bar_outer_x - enc_out,
+            inner_y,
+            bar_outer_x + enc_out,
+            bar_outer_y + enc_out,
+            implant_layer,
+        )
         # Bottom bar
-        _rect(c, -bar_outer_x - enc_out, -bar_outer_y - enc_out,
-              bar_outer_x + enc_out, -inner_y, implant_layer)
+        _rect(
+            c,
+            -bar_outer_x - enc_out,
+            -bar_outer_y - enc_out,
+            bar_outer_x + enc_out,
+            -inner_y,
+            implant_layer,
+        )
         # Left side bar (between inner_y bounds)
-        _rect(c, -side_outer_x - enc_out, -inner_y,
-              -inner_x, inner_y, implant_layer)
+        _rect(c, -side_outer_x - enc_out, -inner_y, -inner_x, inner_y, implant_layer)
         # Right side bar
-        _rect(c, inner_x, -inner_y,
-              side_outer_x + enc_out, inner_y, implant_layer)
+        _rect(c, inner_x, -inner_y, side_outer_x + enc_out, inner_y, implant_layer)
 
 
 # ---------------------------------------------------------------------------
 # Device implant
 # ---------------------------------------------------------------------------
 
-def _device_implant_region(finger_results, bloat, channel_bloat=None,
-                           gate_bloat=0.23, use_gate=True):
+
+def _device_implant_region(
+    finger_results, bloat, channel_bloat=None, gate_bloat=0.23, use_gate=True
+):
     """Build a kdb.Region for the device implant or v5_xtor.
 
     For each finger, creates the typed-diffusion shape:
@@ -398,14 +470,14 @@ def _device_implant_region(finger_results, bloat, channel_bloat=None,
         # Channel extent (hw in Y, full X)
         cx0, cy0, cx1, cy1 = r["channel"]
         cb = channel_bloat if channel_bloat is not None else bloat
-        region.insert(kdb.Box(um(cx0 - cb), um(cy0 - cb),
-                              um(cx1 + cb), um(cy1 + cb)))
+        region.insert(kdb.Box(um(cx0 - cb), um(cy0 - cb), um(cx1 + cb), um(cy1 + cb)))
 
         # Dogbone tabs (individual rectangles, not bounding box)
         for tab in r.get("dogbone_tabs", []):
             t0, t1, t2, t3 = tab
-            region.insert(kdb.Box(um(t0 - bloat), um(t1 - bloat),
-                                  um(t2 + bloat), um(t3 + bloat)))
+            region.insert(
+                kdb.Box(um(t0 - bloat), um(t1 - bloat), um(t2 + bloat), um(t3 + bloat))
+            )
 
     # Gate region: for dogbone devices (w < cdwmin), add each finger's gate
     # individually so the gap between fingers is preserved (nplus notch at
@@ -413,22 +485,34 @@ def _device_implant_region(finger_results, bloat, channel_bloat=None,
     if use_gate and finger_results:
         # Detect dogbone: channel Y extent < active Y extent
         r0 = finger_results[0]
-        is_dogbone = abs(r0["channel"][3] - r0["channel"][1]) < \
-                     abs(r0["active"][3] - r0["active"][1]) - 0.001
+        is_dogbone = (
+            abs(r0["channel"][3] - r0["channel"][1])
+            < abs(r0["active"][3] - r0["active"][1]) - 0.001
+        )
         if is_dogbone and len(finger_results) > 1:
             for r in finger_results:
                 gx0, gy0, gx1, gy1 = r["gate"]
-                region.insert(kdb.Box(
-                    um(gx0 - gate_bloat), um(gy0 - gate_bloat),
-                    um(gx1 + gate_bloat), um(gy1 + gate_bloat)))
+                region.insert(
+                    kdb.Box(
+                        um(gx0 - gate_bloat),
+                        um(gy0 - gate_bloat),
+                        um(gx1 + gate_bloat),
+                        um(gy1 + gate_bloat),
+                    )
+                )
         else:
             gate_x0 = min(r["gate"][0] for r in finger_results)
             gate_y0 = min(r["gate"][1] for r in finger_results)
             gate_x1 = max(r["gate"][2] for r in finger_results)
             gate_y1 = max(r["gate"][3] for r in finger_results)
-            region.insert(kdb.Box(
-                um(gate_x0 - gate_bloat), um(gate_y0 - gate_bloat),
-                um(gate_x1 + gate_bloat), um(gate_y1 + gate_bloat)))
+            region.insert(
+                kdb.Box(
+                    um(gate_x0 - gate_bloat),
+                    um(gate_y0 - gate_bloat),
+                    um(gate_x1 + gate_bloat),
+                    um(gate_y1 + gate_bloat),
+                )
+            )
 
     return region.merged()
 
@@ -436,8 +520,9 @@ def _device_implant_region(finger_results, bloat, channel_bloat=None,
 def _draw_region(c, region, layer_spec):
     """Draw a kdb.Region as polygons on the given layer."""
     for poly in region.each():
-        points = [(_snap(p.x / 1000.0), _snap(p.y / 1000.0))
-                  for p in poly.each_point_hull()]
+        points = [
+            (_snap(p.x / 1000.0), _snap(p.y / 1000.0)) for p in poly.each_point_hull()
+        ]
         if len(points) >= 3:
             c.add_polygon(points, layer=layer_spec)
 
@@ -445,6 +530,7 @@ def _draw_region(c, region, layer_spec):
 # ---------------------------------------------------------------------------
 # Single MOS device geometry computation
 # ---------------------------------------------------------------------------
+
 
 def _mos_geometry(w, l, rules, topc=True, botc=True):
     """Compute geometry for one MOS finger using Magic's algorithm.
@@ -527,13 +613,15 @@ def _mos_geometry(w, l, rules, topc=True, botc=True):
     # Poly gate: hw + poly_ext_top (= gate_extension or gate_to_polycont)
     # Contact pad: hw + gate_to_polycont + poly_surround + contact_size/2
     if topc:
-        top_ext = max(poly_ext_top,
-                      gate_to_polycont + poly_surround + contact_size / 2.0)
+        top_ext = max(
+            poly_ext_top, gate_to_polycont + poly_surround + contact_size / 2.0
+        )
     else:
         top_ext = poly_ext_top
     if botc:
-        bot_ext = max(poly_ext_bot,
-                      gate_to_polycont + poly_surround + contact_size / 2.0)
+        bot_ext = max(
+            poly_ext_bot, gate_to_polycont + poly_surround + contact_size / 2.0
+        )
     else:
         bot_ext = poly_ext_bot
     fh = hw + top_ext + hw + bot_ext
@@ -549,17 +637,25 @@ def _mos_geometry(w, l, rules, topc=True, botc=True):
     # These are typically smaller than the poly extent, so fh is dominated by poly pads.
 
     return dict(
-        w=w, l=l, hw=hw, hl=hl,
+        w=w,
+        l=l,
+        hw=hw,
+        hl=hl,
         gate_to_diffcont=gate_to_diffcont,
         gate_to_polycont=gate_to_polycont,
         gate_extension=gate_extension,
-        diff_grow_d=diff_grow_d, diff_grow_s=diff_grow_s,
-        poly_ext_top=poly_ext_top, poly_ext_bot=poly_ext_bot,
+        diff_grow_d=diff_grow_d,
+        diff_grow_s=diff_grow_s,
+        poly_ext_top=poly_ext_top,
+        poly_ext_bot=poly_ext_bot,
         diffcont_orient=diffcont_orient,
         ddover=ddover,
-        cdw=cdw, cpl=cpl,
-        fw=fw, fh=fh,
-        cdwmin=cdwmin, cplmin=cplmin,
+        cdw=cdw,
+        cpl=cpl,
+        fw=fw,
+        fh=fh,
+        cdwmin=cdwmin,
+        cplmin=cplmin,
     )
 
 
@@ -567,8 +663,10 @@ def _mos_geometry(w, l, rules, topc=True, botc=True):
 # Draw single MOS device finger
 # ---------------------------------------------------------------------------
 
-def _draw_mos_finger(c, cx, cy, geom, rules, evens=1, topc=True, botc=True,
-                     dss=False, asym=False):
+
+def _draw_mos_finger(
+    c, cx, cy, geom, rules, evens=1, topc=True, botc=True, dss=False, asym=False
+):
     """Draw one MOS finger at (cx, cy). Returns device extents."""
     w = geom["w"]
     l = geom["l"]
@@ -592,7 +690,7 @@ def _draw_mos_finger(c, cx, cy, geom, rules, evens=1, topc=True, botc=True,
     if evens == 1:
         dside = -1  # drain left
     else:
-        dside = 1   # drain right
+        dside = 1  # drain right
     sside = -dside
 
     # --- Diffusion (comp) painting ---
@@ -622,12 +720,10 @@ def _draw_mos_finger(c, cx, cy, geom, rules, evens=1, topc=True, botc=True,
         sub_surround_v = rules.get("sub_surround", 0.12)
         if sside == -1:
             # Source on left, drain on right
-            _rect(c, source_left, cy - hw,
-                  cx + hl - sub_surround_v, cy + hw, _L_COMP)
+            _rect(c, source_left, cy - hw, cx + hl - sub_surround_v, cy + hw, _L_COMP)
         else:
             # Source on right, drain on left
-            _rect(c, cx - hl + sub_surround_v, cy - hw,
-                  source_right, cy + hw, _L_COMP)
+            _rect(c, cx - hl + sub_surround_v, cy - hw, source_right, cy + hw, _L_COMP)
     else:
         _rect(c, comp_left, cy - hw, comp_right, cy + hw, _L_COMP)
 
@@ -687,26 +783,52 @@ def _draw_mos_finger(c, cx, cy, geom, rules, evens=1, topc=True, botc=True,
         if dside == -1:
             # Drain on left
             _rect(c, d_outer_edge, cy - hw, d_mid_edge, cy + hw, _L_COMP)
-            _rect(c, d_mid_edge, cy - hw_reduced, d_inner_edge,
-                  cy + hw_reduced, _L_COMP)
+            _rect(
+                c, d_mid_edge, cy - hw_reduced, d_inner_edge, cy + hw_reduced, _L_COMP
+            )
         else:
             # Drain on right
             d_outer_edge = _snap(drain_cx + hc_half + diff_surround)
             d_mid_edge = _snap(drain_cx - ms_phys)
             d_inner_edge = _snap(drain_cx - hc_half)
-            _rect(c, d_inner_edge, cy - hw_reduced, d_mid_edge,
-                  cy + hw_reduced, _L_COMP)
+            _rect(
+                c, d_inner_edge, cy - hw_reduced, d_mid_edge, cy + hw_reduced, _L_COMP
+            )
             _rect(c, d_mid_edge, cy - hw, d_outer_edge, cy + hw, _L_COMP)
         # Still draw drain metal (no comp from draw_contact for asym drain)
         cw_m = max(0, contact_size)
         ch_m = max(cdw, contact_size)
-        _rect(c, drain_cx - cw_m / 2, cy - ch_m / 2 - metal_surround,
-              drain_cx + cw_m / 2, cy + ch_m / 2 + metal_surround, _L_METAL1)
+        _rect(
+            c,
+            drain_cx - cw_m / 2,
+            cy - ch_m / 2 - metal_surround,
+            drain_cx + cw_m / 2,
+            cy + ch_m / 2 + metal_surround,
+            _L_METAL1,
+        )
     else:
-        _draw_contact(c, drain_cx, cy, 0, cdw, rules, _L_COMP, diffcont_orient,
-                      no_cuts=drain_no_cuts)
-    _draw_contact(c, source_cx, cy, 0, cdw, rules, _L_COMP, diffcont_orient,
-                  no_cuts=source_no_cuts)
+        _draw_contact(
+            c,
+            drain_cx,
+            cy,
+            0,
+            cdw,
+            rules,
+            _L_COMP,
+            diffcont_orient,
+            no_cuts=drain_no_cuts,
+        )
+    _draw_contact(
+        c,
+        source_cx,
+        cy,
+        0,
+        cdw,
+        rules,
+        _L_COMP,
+        diffcont_orient,
+        no_cuts=source_no_cuts,
+    )
 
     # --- Poly contacts ---
     if topc:
@@ -792,9 +914,21 @@ def _draw_mos_finger(c, cx, cy, geom, rules, evens=1, topc=True, botc=True,
 # Main MOS drawing — replicates gf180mcu::mos_draw
 # ---------------------------------------------------------------------------
 
-def _mos_draw(c, w, l, nf, rules, is_nfet=True,
-              topc=True, botc=True, guard=True, full_metal=True,
-              dss=False, asym=False):
+
+def _mos_draw(
+    c,
+    w,
+    l,
+    nf,
+    rules,
+    is_nfet=True,
+    topc=True,
+    botc=True,
+    guard=True,
+    full_metal=True,
+    dss=False,
+    asym=False,
+):
     """Draw complete MOSFET with guard ring."""
     contact_size = rules["contact_size"]
     diff_surround = rules["diff_surround"]
@@ -849,9 +983,9 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
     all_finger_results = []
     for i in range(nf):
         fx = start_x + i * dx
-        result = _draw_mos_finger(c, fx, 0, geom, rules,
-                                  evens=evens, topc=topc, botc=botc,
-                                  dss=dss, asym=asym)
+        result = _draw_mos_finger(
+            c, fx, 0, geom, rules, evens=evens, topc=topc, botc=botc, dss=dss, asym=asym
+        )
         all_finger_results.append(result)
         evens = 1 - evens
 
@@ -863,14 +997,17 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
         act_y0 = min(r["active"][1] for r in all_finger_results)
         act_x1 = max(r["active"][2] for r in all_finger_results)
         act_y1 = max(r["active"][3] for r in all_finger_results)
-        _rect(c, act_x0 - 0.18, act_y0 - 0.18,
-              act_x1 + 0.18, act_y1 + 0.18, dev_implant)
+        _rect(
+            c, act_x0 - 0.18, act_y0 - 0.18, act_x1 + 0.18, act_y1 + 0.18, dev_implant
+        )
     elif asym and all_finger_results:
         # 10V asymmetric: gate region bloated by 0.23 (bounding box)
         # + source side channel bloated by 0.16 (no drain channel contribution).
         import klayout.db as kdb
+
         def um(v):
             return round(v * 1000)
+
         impl_region = kdb.Region()
         hw_v = geom["hw"]
         # Gate region: bounding box of all gates, bloated by 0.23
@@ -878,9 +1015,14 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
         gate_y0 = min(r["gate"][1] for r in all_finger_results)
         gate_x1 = max(r["gate"][2] for r in all_finger_results)
         gate_y1 = max(r["gate"][3] for r in all_finger_results)
-        impl_region.insert(kdb.Box(
-            um(gate_x0 - 0.23), um(gate_y0 - 0.23),
-            um(gate_x1 + 0.23), um(gate_y1 + 0.23)))
+        impl_region.insert(
+            kdb.Box(
+                um(gate_x0 - 0.23),
+                um(gate_y0 - 0.23),
+                um(gate_x1 + 0.23),
+                um(gate_y1 + 0.23),
+            )
+        )
         # Source side channel: bloated by 0.16
         for r in all_finger_results:
             scx = r["source_cx"]
@@ -895,9 +1037,11 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
                 # Source on left
                 s_x0 = cx0  # source outer
                 s_x1 = (cx0 + cx1) / 2 + geom["hl"]  # gate right edge
-            impl_region.insert(kdb.Box(
-                um(s_x0 - 0.16), um(-hw_v - 0.16),
-                um(s_x1 + 0.16), um(hw_v + 0.16)))
+            impl_region.insert(
+                kdb.Box(
+                    um(s_x0 - 0.16), um(-hw_v - 0.16), um(s_x1 + 0.16), um(hw_v + 0.16)
+                )
+            )
         impl_region = impl_region.merged()
         _draw_region(c, impl_region, dev_implant)
     elif all_finger_results:
@@ -910,8 +1054,10 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
     # morphological closing to fill tiny CIF notches (matching Magic output).
     if dss and all_finger_results:
         import klayout.db as kdb
+
         def um(v):
             return round(v * 1000)
+
         sab_enc = rules["gate_extension"]
         sab_region = kdb.Region()
         hw_v = geom["hw"]
@@ -927,14 +1073,18 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
                 # Drain contact surround
                 dcx = r["drain_cx"]
                 ds_hw = contact_size / 2.0 + diff_surround
-                sab_region.insert(kdb.Box(
-                    um(dcx - ds_hw), um(-dog_half),
-                    um(dcx + ds_hw), um(dog_half)))
+                sab_region.insert(
+                    kdb.Box(
+                        um(dcx - ds_hw), um(-dog_half), um(dcx + ds_hw), um(dog_half)
+                    )
+                )
                 # Source contact surround
                 scx = r["source_cx"]
-                sab_region.insert(kdb.Box(
-                    um(scx - ds_hw), um(-dog_half),
-                    um(scx + ds_hw), um(dog_half)))
+                sab_region.insert(
+                    kdb.Box(
+                        um(scx - ds_hw), um(-dog_half), um(scx + ds_hw), um(dog_half)
+                    )
+                )
         sab_region = sab_region.merged()
         sab_region = sab_region.sized(round(sab_enc * 1000))
         # Morphological closing: fill tiny CIF notches (< 0.10 um)
@@ -946,6 +1096,7 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
 
     if asym and all_finger_results:
         import klayout.db as kdb
+
         def um(v):
             return round(v * 1000)
 
@@ -989,22 +1140,28 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
 
             if dcx < scx:
                 # Drain left: main body from x0 (outer left) to x_step
-                mvsd_region.insert(kdb.Box(
-                    um(x0), um(-mvsd_y_outer), um(x_step), um(mvsd_y_outer)))
+                mvsd_region.insert(
+                    kdb.Box(um(x0), um(-mvsd_y_outer), um(x_step), um(mvsd_y_outer))
+                )
                 # Wings from x_step to x1
-                mvsd_region.insert(kdb.Box(
-                    um(x_step), um(-mvsd_y_outer), um(x1), um(-inner_y)))
-                mvsd_region.insert(kdb.Box(
-                    um(x_step), um(inner_y), um(x1), um(mvsd_y_outer)))
+                mvsd_region.insert(
+                    kdb.Box(um(x_step), um(-mvsd_y_outer), um(x1), um(-inner_y))
+                )
+                mvsd_region.insert(
+                    kdb.Box(um(x_step), um(inner_y), um(x1), um(mvsd_y_outer))
+                )
             else:
                 # Drain right: main body from x_step to x1 (outer right)
-                mvsd_region.insert(kdb.Box(
-                    um(x_step), um(-mvsd_y_outer), um(x1), um(mvsd_y_outer)))
+                mvsd_region.insert(
+                    kdb.Box(um(x_step), um(-mvsd_y_outer), um(x1), um(mvsd_y_outer))
+                )
                 # Wings from x0 to x_step
-                mvsd_region.insert(kdb.Box(
-                    um(x0), um(-mvsd_y_outer), um(x_step), um(-inner_y)))
-                mvsd_region.insert(kdb.Box(
-                    um(x0), um(inner_y), um(x_step), um(mvsd_y_outer)))
+                mvsd_region.insert(
+                    kdb.Box(um(x0), um(-mvsd_y_outer), um(x_step), um(-inner_y))
+                )
+                mvsd_region.insert(
+                    kdb.Box(um(x0), um(inner_y), um(x_step), um(mvsd_y_outer))
+                )
 
         mvsd_region = mvsd_region.merged()
         _draw_region(c, mvsd_region, mvsd_layer)
@@ -1015,11 +1172,18 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
         hx_c = contact_size / 2.0
         sub_ext = hx_c + diff_surround + sub_surround
         dg_enc = 0.08
-        _rect(c, -(gx / 2 + sub_ext + dg_enc), -(gy / 2 + sub_ext + dg_enc),
-              gx / 2 + sub_ext + dg_enc, gy / 2 + sub_ext + dg_enc, _L_DUALGATE)
+        _rect(
+            c,
+            -(gx / 2 + sub_ext + dg_enc),
+            -(gy / 2 + sub_ext + dg_enc),
+            gx / 2 + sub_ext + dg_enc,
+            gy / 2 + sub_ext + dg_enc,
+            _L_DUALGATE,
+        )
 
     if volt in ("5.0V", "10.0V") and all_finger_results:
         import klayout.db as kdb
+
         def um(v):
             return round(v * 1000)
 
@@ -1041,8 +1205,7 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
                     # Source left
                     src_x0 = _snap(scx - contact_size / 2 - diff_surround)
                     src_x1 = finger_cx + hl_v
-                v5_region.insert(kdb.Box(um(src_x0), um(-hw_v),
-                                         um(src_x1), um(hw_v)))
+                v5_region.insert(kdb.Box(um(src_x0), um(-hw_v), um(src_x1), um(hw_v)))
         else:
             for r in all_finger_results:
                 # Channel comp (main body)
@@ -1062,16 +1225,21 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
         chan_y0 = min(r["channel"][1] for r in all_finger_results)
         chan_x1 = max(r["channel"][2] for r in all_finger_results)
         chan_y1 = max(r["channel"][3] for r in all_finger_results)
-        _rect(c, chan_x0 - 0.26, chan_y0 - 0.26,
-              chan_x1 + 0.26, chan_y1 + 0.26, _L_NAT)
+        _rect(c, chan_x0 - 0.26, chan_y0 - 0.26, chan_x1 + 0.26, chan_y1 + 0.26, _L_NAT)
 
         # Dualgate for NVT
         sub_surround = rules["sub_surround"]
         hx_c = contact_size / 2.0
         sub_ext = hx_c + diff_surround + sub_surround
         dg_enc = 0.08
-        _rect(c, -(gx / 2 + sub_ext + dg_enc), -(gy / 2 + sub_ext + dg_enc),
-              gx / 2 + sub_ext + dg_enc, gy / 2 + sub_ext + dg_enc, _L_DUALGATE)
+        _rect(
+            c,
+            -(gx / 2 + sub_ext + dg_enc),
+            -(gy / 2 + sub_ext + dg_enc),
+            gx / 2 + sub_ext + dg_enc,
+            gy / 2 + sub_ext + dg_enc,
+            _L_DUALGATE,
+        )
 
     # prBoundary removed — Magic's 10x FIXED_BBOX is unnecessarily large
 
@@ -1079,6 +1247,7 @@ def _mos_draw(c, w, l, nf, rules, is_nfet=True,
 # ---------------------------------------------------------------------------
 # nfet
 # ---------------------------------------------------------------------------
+
 
 @gf.cell(tags=["fet"])
 def nfet(
@@ -1104,7 +1273,31 @@ def nfet(
     dss: bool = False,
     asym: bool = False,
 ) -> gf.Component:
-    """Return NFET transistor matching Magic VLSI geometry."""
+    """Return NFET transistor matching Magic VLSI geometry.
+
+    Args:
+        l_gate: gate length in microns.
+        w_gate: gate width in microns.
+        sd_con_col: number of source/drain contact columns.
+        inter_sd_l: inter source/drain length.
+        nf: number of gate fingers.
+        grw: guard-ring width; set to 0 to disable the guard ring.
+        volt: voltage rating ("3.3V", "5.0V", "6.0V", "10.0V").
+        bulk: bulk connection option.
+        con_bet_fin: contacts between fingers.
+        gate_con_pos: gate contact position ("alternating", "top", "bottom").
+        interdig: interdigitated layout toggle.
+        patt: gate pattern option.
+        deepnwell: deep N-well toggle.
+        pcmpgr: P-comp guard-ring toggle.
+        label: add text labels.
+        sd_label: per-terminal source/drain label strings.
+        g_label: gate label strings.
+        sub_label: substrate label string.
+        patt_label: enable pattern labels.
+        dss: drain-side symmetric spacing.
+        asym: asymmetric layout.
+    """
     c = gf.Component()
     rules = dict(_RULES)
     rules["volt"] = volt
@@ -1115,8 +1308,9 @@ def nfet(
         rules["diff_spacing"] = 0.36
         rules["sub_surround"] = 0.16
 
-    _mos_draw(c, w_gate, l_gate, nf, rules, is_nfet=True, guard=grw > 0,
-              dss=dss, asym=asym)
+    _mos_draw(
+        c, w_gate, l_gate, nf, rules, is_nfet=True, guard=grw > 0, dss=dss, asym=asym
+    )
     return c
 
 
@@ -1144,7 +1338,31 @@ def pfet(
     dss: bool = False,
     asym: bool = False,
 ) -> gf.Component:
-    """Return PFET transistor matching Magic VLSI geometry."""
+    """Return PFET transistor matching Magic VLSI geometry.
+
+    Args:
+        l_gate: gate length in microns.
+        w_gate: gate width in microns.
+        sd_con_col: number of source/drain contact columns.
+        inter_sd_l: inter source/drain length.
+        nf: number of gate fingers.
+        grw: guard-ring width; set to 0 to disable the guard ring.
+        volt: voltage rating ("3.3V", "5.0V", "6.0V", "10.0V").
+        bulk: bulk connection option.
+        con_bet_fin: contacts between fingers.
+        gate_con_pos: gate contact position ("alternating", "top", "bottom").
+        interdig: interdigitated layout toggle.
+        patt: gate pattern option.
+        deepnwell: deep N-well toggle.
+        pcmpgr: P-comp guard-ring toggle.
+        label: add text labels.
+        sd_label: per-terminal source/drain label strings.
+        g_label: gate label strings.
+        sub_label: substrate label string.
+        patt_label: enable pattern labels.
+        dss: drain-side symmetric spacing.
+        asym: asymmetric layout.
+    """
     c = gf.Component()
     rules = dict(_RULES)
     rules["volt"] = volt
@@ -1155,8 +1373,9 @@ def pfet(
         rules["diff_spacing"] = 0.36
         rules["sub_surround"] = 0.16
 
-    _mos_draw(c, w_gate, l_gate, nf, rules, is_nfet=False, guard=grw > 0,
-              dss=dss, asym=asym)
+    _mos_draw(
+        c, w_gate, l_gate, nf, rules, is_nfet=False, guard=grw > 0, dss=dss, asym=asym
+    )
     return c
 
 
@@ -1179,7 +1398,26 @@ def nfet_06v0_nvt(
     sub_label: str = "",
     patt_label: bool = False,
 ) -> gf.Component:
-    """Return Native NFET 6V transistor matching Magic VLSI geometry."""
+    """Return Native NFET 6V transistor matching Magic VLSI geometry.
+
+    Args:
+        l_gate: gate length in microns.
+        w_gate: gate width in microns.
+        sd_con_col: number of source/drain contact columns.
+        inter_sd_l: inter source/drain length.
+        nf: number of gate fingers.
+        grw: guard-ring width; set to 0 to disable the guard ring.
+        bulk: bulk connection option.
+        con_bet_fin: contacts between fingers.
+        gate_con_pos: gate contact position ("alternating", "top", "bottom").
+        interdig: interdigitated layout toggle.
+        patt: gate pattern option.
+        label: add text labels.
+        sd_label: per-terminal source/drain label strings.
+        g_label: gate label strings.
+        sub_label: substrate label string.
+        patt_label: enable pattern labels.
+    """
     c = gf.Component()
     rules = dict(_RULES)
     rules["volt"] = "nvt"

--- a/gf180mcu/cells/res.py
+++ b/gf180mcu/cells/res.py
@@ -85,7 +85,9 @@ def _draw_contacts_2d(
 # We precompute the shapes from reference analysis.
 
 _NSD_IMPLANT_OUTER_BLOAT = 0.16  # nplus extends outside comp by this amount
-_NSD_IMPLANT_INNER_BLOAT = 0.11  # nplus extends inside comp (toward center) by this amount
+_NSD_IMPLANT_INNER_BLOAT = (
+    0.11  # nplus extends inside comp (toward center) by this amount
+)
 # psd bloat is more complex - approximately 0.02-0.03 with corner patches
 
 
@@ -164,9 +166,7 @@ def _guard_ring(
     )
 
     # 2. Draw implant layer around guard ring comp
-    _draw_guard_ring_implant(
-        c, gw, gh, implant_layer, implant_bloat, is_psd
-    )
+    _draw_guard_ring_implant(c, gw, gh, implant_layer, implant_bloat, is_psd)
 
     # 3. Draw metal ring (full metal ring as seen in references)
     _draw_guard_ring_metal(c, gw, gh)
@@ -274,26 +274,42 @@ def _draw_guard_ring_implant(
 
         # Top bar
         c.add_polygon(
-            [(-outer_x, inner_y), (outer_x, inner_y),
-             (outer_x, outer_y), (-outer_x, outer_y)],
+            [
+                (-outer_x, inner_y),
+                (outer_x, inner_y),
+                (outer_x, outer_y),
+                (-outer_x, outer_y),
+            ],
             layer=implant_layer,
         )
         # Bottom bar
         c.add_polygon(
-            [(-outer_x, -outer_y), (outer_x, -outer_y),
-             (outer_x, -inner_y), (-outer_x, -inner_y)],
+            [
+                (-outer_x, -outer_y),
+                (outer_x, -outer_y),
+                (outer_x, -inner_y),
+                (-outer_x, -inner_y),
+            ],
             layer=implant_layer,
         )
         # Left bar
         c.add_polygon(
-            [(-outer_x, -inner_y), (-inner_x, -inner_y),
-             (-inner_x, inner_y), (-outer_x, inner_y)],
+            [
+                (-outer_x, -inner_y),
+                (-inner_x, -inner_y),
+                (-inner_x, inner_y),
+                (-outer_x, inner_y),
+            ],
             layer=implant_layer,
         )
         # Right bar
         c.add_polygon(
-            [(inner_x, -inner_y), (outer_x, -inner_y),
-             (outer_x, inner_y), (inner_x, inner_y)],
+            [
+                (inner_x, -inner_y),
+                (outer_x, -inner_y),
+                (outer_x, inner_y),
+                (inner_x, inner_y),
+            ],
             layer=implant_layer,
         )
     else:
@@ -311,10 +327,10 @@ def _draw_guard_ring_implant(
         ci_y = hh - hdifft  # comp inner Y
 
         # psd bloat values (from reference analysis, consistent across sizes)
-        b_out = 0.02   # bloat on comp outer edge for top/bottom bars
+        b_out = 0.02  # bloat on comp outer edge for top/bottom bars
         b_side = 0.03  # bloat on comp inner/outer edge for side bars
         side_y_gap = 0.125  # how far below ci_y the side bars end
-        corner_h = 0.105   # corner patch height = side_y_gap - b_out
+        corner_h = 0.105  # corner patch height = side_y_gap - b_out
 
         # Inner X edge of side bars / corner patches
         side_inner_x = ci_x - b_side
@@ -501,8 +517,7 @@ def _metal_res(
 
     # Metal (centered, w x (l + 2*ext))
     c.add_polygon(
-        [(-hw, -(hl + ext)), (hw, -(hl + ext)),
-         (hw, hl + ext), (-hw, hl + ext)],
+        [(-hw, -(hl + ext)), (hw, -(hl + ext)), (hw, hl + ext), (-hw, hl + ext)],
         layer=m_layer,
     )
 
@@ -590,8 +605,7 @@ def _poly_res(
 
     # 2. Poly2 (30,0): w x 2*poly_ext_y centered
     c.add_polygon(
-        [(-hw, -poly_ext_y), (hw, -poly_ext_y),
-         (hw, poly_ext_y), (-hw, poly_ext_y)],
+        [(-hw, -poly_ext_y), (hw, -poly_ext_y), (hw, poly_ext_y), (-hw, poly_ext_y)],
         layer=layer["poly2"],
     )
 
@@ -599,8 +613,7 @@ def _poly_res(
     if has_sab:
         sab_hw = hw + sab_ext_x
         c.add_polygon(
-            [(-sab_hw, -hl), (sab_hw, -hl),
-             (sab_hw, hl), (-sab_hw, hl)],
+            [(-sab_hw, -hl), (sab_hw, -hl), (sab_hw, hl), (-sab_hw, hl)],
             layer=layer["sab"],
         )
 
@@ -646,7 +659,9 @@ def _poly_res(
     gy = fh + 2 * (end_spacing + _DIFF_SURROUND) + _CONTACT_SIZE
 
     _guard_ring(
-        c, gx, gy,
+        c,
+        gx,
+        gy,
         plus_diff_layer=layer["comp"],
         plus_contact_layer=layer["contact"],
         sub_type_layer=well_layer,
@@ -711,15 +726,13 @@ def _diff_res(
     # 2. SAB (49,0): extends sab_ext_x beyond res_mk in X, same Y as res_mk
     sab_hw = hw + sab_ext_x
     c.add_polygon(
-        [(-sab_hw, -hl), (sab_hw, -hl),
-         (sab_hw, hl), (-sab_hw, hl)],
+        [(-sab_hw, -hl), (sab_hw, -hl), (sab_hw, hl), (-sab_hw, hl)],
         layer=layer["sab"],
     )
 
     # 3. Comp body (22,0): w x 2*comp_ext_y centered
     c.add_polygon(
-        [(-hw, -comp_ext_y), (hw, -comp_ext_y),
-         (hw, comp_ext_y), (-hw, comp_ext_y)],
+        [(-hw, -comp_ext_y), (hw, -comp_ext_y), (hw, comp_ext_y), (-hw, comp_ext_y)],
         layer=layer["comp"],
     )
 
@@ -760,7 +773,9 @@ def _diff_res(
     gy = fh + 2 * (end_spacing + _DIFF_SURROUND) + _CONTACT_SIZE
 
     _guard_ring(
-        c, gx, gy,
+        c,
+        gx,
+        gy,
         plus_diff_layer=layer["comp"],
         plus_contact_layer=layer["contact"],
         sub_type_layer=well_layer,
@@ -809,8 +824,7 @@ def _well_res(
 
     # Draw nwell
     c.add_polygon(
-        [(-hw, -nwell_hy), (hw, -nwell_hy),
-         (hw, nwell_hy), (-hw, nwell_hy)],
+        [(-hw, -nwell_hy), (hw, -nwell_hy), (hw, nwell_hy), (-hw, nwell_hy)],
         layer=layer["nwell"],
     )
 
@@ -881,13 +895,21 @@ def _well_res(
     m_hw = max(cpl, _CONTACT_SIZE) / 2 + _METAL_SURROUND
     m_hh = _CONTACT_SIZE / 2
     c.add_polygon(
-        [(-m_hw, end_cy - m_hh), (m_hw, end_cy - m_hh),
-         (m_hw, end_cy + m_hh), (-m_hw, end_cy + m_hh)],
+        [
+            (-m_hw, end_cy - m_hh),
+            (m_hw, end_cy - m_hh),
+            (m_hw, end_cy + m_hh),
+            (-m_hw, end_cy + m_hh),
+        ],
         layer=layer["metal1"],
     )
     c.add_polygon(
-        [(-m_hw, -(end_cy + m_hh)), (m_hw, -(end_cy + m_hh)),
-         (m_hw, -(end_cy - m_hh)), (-m_hw, -(end_cy - m_hh))],
+        [
+            (-m_hw, -(end_cy + m_hh)),
+            (m_hw, -(end_cy + m_hh)),
+            (m_hw, -(end_cy - m_hh)),
+            (-m_hw, -(end_cy - m_hh)),
+        ],
         layer=layer["metal1"],
     )
 
@@ -907,8 +929,8 @@ def _well_res(
     well_ext = _HX + _DIFF_SURROUND + _SUB_SURROUND
     lvpwell_ox = gx / 2 + well_ext  # outer X
     lvpwell_oy = gy / 2 + well_ext  # outer Y
-    lvpwell_ix = hw                  # inner X = nwell body edge
-    lvpwell_iy = nwell_hy            # inner Y = nwell body edge
+    lvpwell_ix = hw  # inner X = nwell body edge
+    lvpwell_iy = nwell_hy  # inner Y = nwell body edge
 
     # Top bar
     c.add_polygon(
@@ -952,7 +974,9 @@ def _well_res(
     )
 
     _guard_ring(
-        c, gx, gy,
+        c,
+        gx,
+        gy,
         plus_diff_layer=layer["comp"],
         plus_contact_layer=layer["contact"],
         sub_type_layer=layer["lvpwell"],
@@ -1124,8 +1148,7 @@ def _highR_poly_res(
 
     # 5. Poly2
     c.add_polygon(
-        [(-hw, -poly_ext_y), (hw, -poly_ext_y),
-         (hw, poly_ext_y), (-hw, poly_ext_y)],
+        [(-hw, -poly_ext_y), (hw, -poly_ext_y), (hw, poly_ext_y), (-hw, poly_ext_y)],
         layer=layer["poly2"],
     )
 
@@ -1172,7 +1195,9 @@ def _highR_poly_res(
     well_ext_extra_6p0 = 0.04 if is_6p0 else 0.0
 
     _guard_ring(
-        c, gx, gy,
+        c,
+        gx,
+        gy,
         plus_diff_layer=layer["comp"],
         plus_contact_layer=layer["contact"],
         sub_type_layer=well_layer,
@@ -1270,8 +1295,11 @@ def res(
 
     if res_type in ("rm1", "rm2", "rm3"):
         ext = 0.315
-        m_layer = {"rm1": layer["metal1"], "rm2": layer["metal2"],
-                    "rm3": layer["metal3"]}[res_type]
+        m_layer = {
+            "rm1": layer["metal1"],
+            "rm2": layer["metal2"],
+            "rm3": layer["metal3"],
+        }[res_type]
         out.add_port(
             name="r0",
             center=(0, hl + ext),

--- a/gf180mcu/logic/__init__.py
+++ b/gf180mcu/logic/__init__.py
@@ -29,2495 +29,3767 @@ _SRC = Path(__file__).parent.parent / "src"
 
 # ── 7-track 5V standard cells ──
 
+
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__addf_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__addf_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__addf_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__addh_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/addh/gf180mcu_fd_sc_mcu7t5v0__addh_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/addh/gf180mcu_fd_sc_mcu7t5v0__addh_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__addh_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/addh/gf180mcu_fd_sc_mcu7t5v0__addh_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/addh/gf180mcu_fd_sc_mcu7t5v0__addh_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__addh_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/addh/gf180mcu_fd_sc_mcu7t5v0__addh_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/addh/gf180mcu_fd_sc_mcu7t5v0__addh_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__and2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and2/gf180mcu_fd_sc_mcu7t5v0__and2_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and2/gf180mcu_fd_sc_mcu7t5v0__and2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__and2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and2/gf180mcu_fd_sc_mcu7t5v0__and2_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and2/gf180mcu_fd_sc_mcu7t5v0__and2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__and2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and2/gf180mcu_fd_sc_mcu7t5v0__and2_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and2/gf180mcu_fd_sc_mcu7t5v0__and2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__and3_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and3/gf180mcu_fd_sc_mcu7t5v0__and3_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and3/gf180mcu_fd_sc_mcu7t5v0__and3_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__and3_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and3/gf180mcu_fd_sc_mcu7t5v0__and3_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and3/gf180mcu_fd_sc_mcu7t5v0__and3_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__and3_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and3/gf180mcu_fd_sc_mcu7t5v0__and3_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and3/gf180mcu_fd_sc_mcu7t5v0__and3_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__and4_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and4/gf180mcu_fd_sc_mcu7t5v0__and4_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and4/gf180mcu_fd_sc_mcu7t5v0__and4_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__and4_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and4/gf180mcu_fd_sc_mcu7t5v0__and4_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and4/gf180mcu_fd_sc_mcu7t5v0__and4_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__and4_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and4/gf180mcu_fd_sc_mcu7t5v0__and4_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/and4/gf180mcu_fd_sc_mcu7t5v0__and4_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__antenna() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/antenna/gf180mcu_fd_sc_mcu7t5v0__antenna.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/antenna/gf180mcu_fd_sc_mcu7t5v0__antenna.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi21_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi21/gf180mcu_fd_sc_mcu7t5v0__aoi21_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi21/gf180mcu_fd_sc_mcu7t5v0__aoi21_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi21_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi21/gf180mcu_fd_sc_mcu7t5v0__aoi21_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi21/gf180mcu_fd_sc_mcu7t5v0__aoi21_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi21_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi21/gf180mcu_fd_sc_mcu7t5v0__aoi21_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi21/gf180mcu_fd_sc_mcu7t5v0__aoi21_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi211_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi211/gf180mcu_fd_sc_mcu7t5v0__aoi211_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi211/gf180mcu_fd_sc_mcu7t5v0__aoi211_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi211_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi211/gf180mcu_fd_sc_mcu7t5v0__aoi211_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi211/gf180mcu_fd_sc_mcu7t5v0__aoi211_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi211_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi211/gf180mcu_fd_sc_mcu7t5v0__aoi211_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi211/gf180mcu_fd_sc_mcu7t5v0__aoi211_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi22_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi22/gf180mcu_fd_sc_mcu7t5v0__aoi22_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi22/gf180mcu_fd_sc_mcu7t5v0__aoi22_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi22_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi22/gf180mcu_fd_sc_mcu7t5v0__aoi22_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi22/gf180mcu_fd_sc_mcu7t5v0__aoi22_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi22_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi22/gf180mcu_fd_sc_mcu7t5v0__aoi22_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi22/gf180mcu_fd_sc_mcu7t5v0__aoi22_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi221_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi221/gf180mcu_fd_sc_mcu7t5v0__aoi221_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi221/gf180mcu_fd_sc_mcu7t5v0__aoi221_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi221_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi221/gf180mcu_fd_sc_mcu7t5v0__aoi221_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi221/gf180mcu_fd_sc_mcu7t5v0__aoi221_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi221_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi221/gf180mcu_fd_sc_mcu7t5v0__aoi221_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi221/gf180mcu_fd_sc_mcu7t5v0__aoi221_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi222_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi222/gf180mcu_fd_sc_mcu7t5v0__aoi222_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi222/gf180mcu_fd_sc_mcu7t5v0__aoi222_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi222_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi222/gf180mcu_fd_sc_mcu7t5v0__aoi222_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi222/gf180mcu_fd_sc_mcu7t5v0__aoi222_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__aoi222_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi222/gf180mcu_fd_sc_mcu7t5v0__aoi222_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/aoi222/gf180mcu_fd_sc_mcu7t5v0__aoi222_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__buf_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__buf_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_12.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__buf_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_16.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__buf_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__buf_20() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_20.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_20.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__buf_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_3.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__buf_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__buf_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_8.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__bufz_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__bufz_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_12.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__bufz_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_16.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__bufz_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__bufz_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_3.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__bufz_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__bufz_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_8.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkbuf_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkbuf_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_12.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkbuf_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_16.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkbuf_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkbuf_20() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_20.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_20.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkbuf_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_3.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkbuf_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkbuf_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_8.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_12.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_16.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_20() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_20.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_20.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_3.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_8.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnq/gf180mcu_fd_sc_mcu7t5v0__dffnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnq/gf180mcu_fd_sc_mcu7t5v0__dffnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnq/gf180mcu_fd_sc_mcu7t5v0__dffnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnq/gf180mcu_fd_sc_mcu7t5v0__dffnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnq/gf180mcu_fd_sc_mcu7t5v0__dffnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnq/gf180mcu_fd_sc_mcu7t5v0__dffnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffnrnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnrnq/gf180mcu_fd_sc_mcu7t5v0__dffnrnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnrnq/gf180mcu_fd_sc_mcu7t5v0__dffnrnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffnrnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnrnq/gf180mcu_fd_sc_mcu7t5v0__dffnrnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnrnq/gf180mcu_fd_sc_mcu7t5v0__dffnrnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffnrnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnrnq/gf180mcu_fd_sc_mcu7t5v0__dffnrnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnrnq/gf180mcu_fd_sc_mcu7t5v0__dffnrnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnrsnq/gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnrsnq/gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnrsnq/gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnrsnq/gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnrsnq/gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnrsnq/gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffnsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnsnq/gf180mcu_fd_sc_mcu7t5v0__dffnsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnsnq/gf180mcu_fd_sc_mcu7t5v0__dffnsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffnsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnsnq/gf180mcu_fd_sc_mcu7t5v0__dffnsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnsnq/gf180mcu_fd_sc_mcu7t5v0__dffnsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffnsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnsnq/gf180mcu_fd_sc_mcu7t5v0__dffnsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffnsnq/gf180mcu_fd_sc_mcu7t5v0__dffnsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__dffq_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__dffq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__dffq_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__dffq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__dffq_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__dffq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffrnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__dffrnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__dffrnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffrnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__dffrnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__dffrnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffrnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__dffrnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__dffrnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffrnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffrnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffrnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffrsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__dffrsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__dffrsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffrsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__dffrsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__dffrsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffrsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__dffrsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__dffrsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__dffsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__dffsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__dffsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__dffsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dffsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__dffsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__dffsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dlya_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlya/gf180mcu_fd_sc_mcu7t5v0__dlya_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlya/gf180mcu_fd_sc_mcu7t5v0__dlya_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dlya_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlya/gf180mcu_fd_sc_mcu7t5v0__dlya_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlya/gf180mcu_fd_sc_mcu7t5v0__dlya_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dlya_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlya/gf180mcu_fd_sc_mcu7t5v0__dlya_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlya/gf180mcu_fd_sc_mcu7t5v0__dlya_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dlyb_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyb/gf180mcu_fd_sc_mcu7t5v0__dlyb_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyb/gf180mcu_fd_sc_mcu7t5v0__dlyb_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dlyb_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyb/gf180mcu_fd_sc_mcu7t5v0__dlyb_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyb/gf180mcu_fd_sc_mcu7t5v0__dlyb_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dlyb_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyb/gf180mcu_fd_sc_mcu7t5v0__dlyb_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyb/gf180mcu_fd_sc_mcu7t5v0__dlyb_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dlyc_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyc/gf180mcu_fd_sc_mcu7t5v0__dlyc_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyc/gf180mcu_fd_sc_mcu7t5v0__dlyc_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dlyc_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyc/gf180mcu_fd_sc_mcu7t5v0__dlyc_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyc/gf180mcu_fd_sc_mcu7t5v0__dlyc_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dlyc_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyc/gf180mcu_fd_sc_mcu7t5v0__dlyc_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyc/gf180mcu_fd_sc_mcu7t5v0__dlyc_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dlyd_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyd/gf180mcu_fd_sc_mcu7t5v0__dlyd_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyd/gf180mcu_fd_sc_mcu7t5v0__dlyd_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dlyd_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyd/gf180mcu_fd_sc_mcu7t5v0__dlyd_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyd/gf180mcu_fd_sc_mcu7t5v0__dlyd_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__dlyd_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyd/gf180mcu_fd_sc_mcu7t5v0__dlyd_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/dlyd/gf180mcu_fd_sc_mcu7t5v0__dlyd_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__endcap() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/endcap/gf180mcu_fd_sc_mcu7t5v0__endcap.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/endcap/gf180mcu_fd_sc_mcu7t5v0__endcap.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__fill_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__fill_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_16.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__fill_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__fill_32() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_32.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_32.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__fill_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__fill_64() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_64.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_64.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__fill_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_8.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__fillcap_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_16.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__fillcap_32() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_32.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_32.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__fillcap_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__fillcap_64() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_64.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_64.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__fillcap_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_8.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__filltie() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/filltie/gf180mcu_fd_sc_mcu7t5v0__filltie.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/filltie/gf180mcu_fd_sc_mcu7t5v0__filltie.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__hold() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/hold/gf180mcu_fd_sc_mcu7t5v0__hold.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/hold/gf180mcu_fd_sc_mcu7t5v0__hold.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__icgtn_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/icgtn/gf180mcu_fd_sc_mcu7t5v0__icgtn_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/icgtn/gf180mcu_fd_sc_mcu7t5v0__icgtn_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__icgtn_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/icgtn/gf180mcu_fd_sc_mcu7t5v0__icgtn_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/icgtn/gf180mcu_fd_sc_mcu7t5v0__icgtn_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__icgtn_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/icgtn/gf180mcu_fd_sc_mcu7t5v0__icgtn_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/icgtn/gf180mcu_fd_sc_mcu7t5v0__icgtn_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__icgtp_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/icgtp/gf180mcu_fd_sc_mcu7t5v0__icgtp_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/icgtp/gf180mcu_fd_sc_mcu7t5v0__icgtp_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__icgtp_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/icgtp/gf180mcu_fd_sc_mcu7t5v0__icgtp_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/icgtp/gf180mcu_fd_sc_mcu7t5v0__icgtp_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__icgtp_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/icgtp/gf180mcu_fd_sc_mcu7t5v0__icgtp_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/icgtp/gf180mcu_fd_sc_mcu7t5v0__icgtp_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_12.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_16.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_20() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_20.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_20.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_3.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__clkinv_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_8.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__clkinv_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__inv_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__inv_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_12.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__inv_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_16.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__inv_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__inv_20() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_20.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_20.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__inv_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_3.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__inv_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__inv_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_8.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__invz_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__invz_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_12.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__invz_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_16.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__invz_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__invz_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_3.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__invz_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__invz_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_8.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__latq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latq/gf180mcu_fd_sc_mcu7t5v0__latq_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latq/gf180mcu_fd_sc_mcu7t5v0__latq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__latq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latq/gf180mcu_fd_sc_mcu7t5v0__latq_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latq/gf180mcu_fd_sc_mcu7t5v0__latq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__latq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latq/gf180mcu_fd_sc_mcu7t5v0__latq_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latq/gf180mcu_fd_sc_mcu7t5v0__latq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__latrnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latrnq/gf180mcu_fd_sc_mcu7t5v0__latrnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/latrnq/gf180mcu_fd_sc_mcu7t5v0__latrnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__latrnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latrnq/gf180mcu_fd_sc_mcu7t5v0__latrnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/latrnq/gf180mcu_fd_sc_mcu7t5v0__latrnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__latrnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latrnq/gf180mcu_fd_sc_mcu7t5v0__latrnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/latrnq/gf180mcu_fd_sc_mcu7t5v0__latrnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__latrsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latrsnq/gf180mcu_fd_sc_mcu7t5v0__latrsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/latrsnq/gf180mcu_fd_sc_mcu7t5v0__latrsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__latrsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latrsnq/gf180mcu_fd_sc_mcu7t5v0__latrsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/latrsnq/gf180mcu_fd_sc_mcu7t5v0__latrsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__latrsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latrsnq/gf180mcu_fd_sc_mcu7t5v0__latrsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/latrsnq/gf180mcu_fd_sc_mcu7t5v0__latrsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__latsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latsnq/gf180mcu_fd_sc_mcu7t5v0__latsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/latsnq/gf180mcu_fd_sc_mcu7t5v0__latsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__latsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latsnq/gf180mcu_fd_sc_mcu7t5v0__latsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/latsnq/gf180mcu_fd_sc_mcu7t5v0__latsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__latsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/latsnq/gf180mcu_fd_sc_mcu7t5v0__latsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/latsnq/gf180mcu_fd_sc_mcu7t5v0__latsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__mux2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/mux2/gf180mcu_fd_sc_mcu7t5v0__mux2_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/mux2/gf180mcu_fd_sc_mcu7t5v0__mux2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__mux2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/mux2/gf180mcu_fd_sc_mcu7t5v0__mux2_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/mux2/gf180mcu_fd_sc_mcu7t5v0__mux2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__mux2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/mux2/gf180mcu_fd_sc_mcu7t5v0__mux2_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/mux2/gf180mcu_fd_sc_mcu7t5v0__mux2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__mux4_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/mux4/gf180mcu_fd_sc_mcu7t5v0__mux4_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/mux4/gf180mcu_fd_sc_mcu7t5v0__mux4_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__mux4_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/mux4/gf180mcu_fd_sc_mcu7t5v0__mux4_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/mux4/gf180mcu_fd_sc_mcu7t5v0__mux4_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__mux4_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/mux4/gf180mcu_fd_sc_mcu7t5v0__mux4_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/mux4/gf180mcu_fd_sc_mcu7t5v0__mux4_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nand2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nand2/gf180mcu_fd_sc_mcu7t5v0__nand2_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/nand2/gf180mcu_fd_sc_mcu7t5v0__nand2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nand2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nand2/gf180mcu_fd_sc_mcu7t5v0__nand2_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/nand2/gf180mcu_fd_sc_mcu7t5v0__nand2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nand2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nand2/gf180mcu_fd_sc_mcu7t5v0__nand2_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/nand2/gf180mcu_fd_sc_mcu7t5v0__nand2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nand3_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nand3/gf180mcu_fd_sc_mcu7t5v0__nand3_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/nand3/gf180mcu_fd_sc_mcu7t5v0__nand3_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nand3_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nand3/gf180mcu_fd_sc_mcu7t5v0__nand3_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/nand3/gf180mcu_fd_sc_mcu7t5v0__nand3_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nand3_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nand3/gf180mcu_fd_sc_mcu7t5v0__nand3_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/nand3/gf180mcu_fd_sc_mcu7t5v0__nand3_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nand4_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nand4/gf180mcu_fd_sc_mcu7t5v0__nand4_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/nand4/gf180mcu_fd_sc_mcu7t5v0__nand4_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nand4_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nand4/gf180mcu_fd_sc_mcu7t5v0__nand4_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/nand4/gf180mcu_fd_sc_mcu7t5v0__nand4_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nand4_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nand4/gf180mcu_fd_sc_mcu7t5v0__nand4_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/nand4/gf180mcu_fd_sc_mcu7t5v0__nand4_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nor2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor2/gf180mcu_fd_sc_mcu7t5v0__nor2_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor2/gf180mcu_fd_sc_mcu7t5v0__nor2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nor2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor2/gf180mcu_fd_sc_mcu7t5v0__nor2_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor2/gf180mcu_fd_sc_mcu7t5v0__nor2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nor2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor2/gf180mcu_fd_sc_mcu7t5v0__nor2_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor2/gf180mcu_fd_sc_mcu7t5v0__nor2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nor3_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor3/gf180mcu_fd_sc_mcu7t5v0__nor3_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor3/gf180mcu_fd_sc_mcu7t5v0__nor3_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nor3_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor3/gf180mcu_fd_sc_mcu7t5v0__nor3_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor3/gf180mcu_fd_sc_mcu7t5v0__nor3_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nor3_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor3/gf180mcu_fd_sc_mcu7t5v0__nor3_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor3/gf180mcu_fd_sc_mcu7t5v0__nor3_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nor4_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor4/gf180mcu_fd_sc_mcu7t5v0__nor4_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor4/gf180mcu_fd_sc_mcu7t5v0__nor4_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nor4_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor4/gf180mcu_fd_sc_mcu7t5v0__nor4_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor4/gf180mcu_fd_sc_mcu7t5v0__nor4_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__nor4_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor4/gf180mcu_fd_sc_mcu7t5v0__nor4_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/nor4/gf180mcu_fd_sc_mcu7t5v0__nor4_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai21_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai21/gf180mcu_fd_sc_mcu7t5v0__oai21_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai21/gf180mcu_fd_sc_mcu7t5v0__oai21_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai21_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai21/gf180mcu_fd_sc_mcu7t5v0__oai21_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai21/gf180mcu_fd_sc_mcu7t5v0__oai21_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai21_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai21/gf180mcu_fd_sc_mcu7t5v0__oai21_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai21/gf180mcu_fd_sc_mcu7t5v0__oai21_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai211_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai211/gf180mcu_fd_sc_mcu7t5v0__oai211_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai211/gf180mcu_fd_sc_mcu7t5v0__oai211_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai211_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai211/gf180mcu_fd_sc_mcu7t5v0__oai211_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai211/gf180mcu_fd_sc_mcu7t5v0__oai211_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai211_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai211/gf180mcu_fd_sc_mcu7t5v0__oai211_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai211/gf180mcu_fd_sc_mcu7t5v0__oai211_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai22_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai22/gf180mcu_fd_sc_mcu7t5v0__oai22_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai22/gf180mcu_fd_sc_mcu7t5v0__oai22_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai22_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai22/gf180mcu_fd_sc_mcu7t5v0__oai22_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai22/gf180mcu_fd_sc_mcu7t5v0__oai22_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai22_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai22/gf180mcu_fd_sc_mcu7t5v0__oai22_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai22/gf180mcu_fd_sc_mcu7t5v0__oai22_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai221_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai221/gf180mcu_fd_sc_mcu7t5v0__oai221_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai221/gf180mcu_fd_sc_mcu7t5v0__oai221_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai221_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai221/gf180mcu_fd_sc_mcu7t5v0__oai221_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai221/gf180mcu_fd_sc_mcu7t5v0__oai221_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai221_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai221/gf180mcu_fd_sc_mcu7t5v0__oai221_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai221/gf180mcu_fd_sc_mcu7t5v0__oai221_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai222_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai222/gf180mcu_fd_sc_mcu7t5v0__oai222_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai222/gf180mcu_fd_sc_mcu7t5v0__oai222_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai222_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai222/gf180mcu_fd_sc_mcu7t5v0__oai222_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai222/gf180mcu_fd_sc_mcu7t5v0__oai222_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai222_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai222/gf180mcu_fd_sc_mcu7t5v0__oai222_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai222/gf180mcu_fd_sc_mcu7t5v0__oai222_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai31_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai31/gf180mcu_fd_sc_mcu7t5v0__oai31_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai31/gf180mcu_fd_sc_mcu7t5v0__oai31_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai31_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai31/gf180mcu_fd_sc_mcu7t5v0__oai31_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai31/gf180mcu_fd_sc_mcu7t5v0__oai31_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai31_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai31/gf180mcu_fd_sc_mcu7t5v0__oai31_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai31/gf180mcu_fd_sc_mcu7t5v0__oai31_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai32_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai32/gf180mcu_fd_sc_mcu7t5v0__oai32_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai32/gf180mcu_fd_sc_mcu7t5v0__oai32_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai32_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai32/gf180mcu_fd_sc_mcu7t5v0__oai32_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai32/gf180mcu_fd_sc_mcu7t5v0__oai32_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai32_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai32/gf180mcu_fd_sc_mcu7t5v0__oai32_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai32/gf180mcu_fd_sc_mcu7t5v0__oai32_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai33_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai33/gf180mcu_fd_sc_mcu7t5v0__oai33_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai33/gf180mcu_fd_sc_mcu7t5v0__oai33_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai33_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai33/gf180mcu_fd_sc_mcu7t5v0__oai33_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai33/gf180mcu_fd_sc_mcu7t5v0__oai33_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__oai33_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/oai33/gf180mcu_fd_sc_mcu7t5v0__oai33_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/oai33/gf180mcu_fd_sc_mcu7t5v0__oai33_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__or2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or2/gf180mcu_fd_sc_mcu7t5v0__or2_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or2/gf180mcu_fd_sc_mcu7t5v0__or2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__or2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or2/gf180mcu_fd_sc_mcu7t5v0__or2_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or2/gf180mcu_fd_sc_mcu7t5v0__or2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__or2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or2/gf180mcu_fd_sc_mcu7t5v0__or2_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or2/gf180mcu_fd_sc_mcu7t5v0__or2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__or3_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or3/gf180mcu_fd_sc_mcu7t5v0__or3_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or3/gf180mcu_fd_sc_mcu7t5v0__or3_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__or3_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or3/gf180mcu_fd_sc_mcu7t5v0__or3_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or3/gf180mcu_fd_sc_mcu7t5v0__or3_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__or3_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or3/gf180mcu_fd_sc_mcu7t5v0__or3_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or3/gf180mcu_fd_sc_mcu7t5v0__or3_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__or4_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or4/gf180mcu_fd_sc_mcu7t5v0__or4_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or4/gf180mcu_fd_sc_mcu7t5v0__or4_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__or4_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or4/gf180mcu_fd_sc_mcu7t5v0__or4_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or4/gf180mcu_fd_sc_mcu7t5v0__or4_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__or4_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or4/gf180mcu_fd_sc_mcu7t5v0__or4_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/or4/gf180mcu_fd_sc_mcu7t5v0__or4_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffrnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffrnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffrnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__sdffsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/sdffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__tieh() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/tieh/gf180mcu_fd_sc_mcu7t5v0__tieh.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/tieh/gf180mcu_fd_sc_mcu7t5v0__tieh.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__tiel() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/tiel/gf180mcu_fd_sc_mcu7t5v0__tiel.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/tiel/gf180mcu_fd_sc_mcu7t5v0__tiel.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__xnor2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xnor2/gf180mcu_fd_sc_mcu7t5v0__xnor2_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/xnor2/gf180mcu_fd_sc_mcu7t5v0__xnor2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__xnor2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xnor2/gf180mcu_fd_sc_mcu7t5v0__xnor2_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/xnor2/gf180mcu_fd_sc_mcu7t5v0__xnor2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__xnor2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xnor2/gf180mcu_fd_sc_mcu7t5v0__xnor2_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/xnor2/gf180mcu_fd_sc_mcu7t5v0__xnor2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__xnor3_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xnor3/gf180mcu_fd_sc_mcu7t5v0__xnor3_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/xnor3/gf180mcu_fd_sc_mcu7t5v0__xnor3_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__xnor3_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xnor3/gf180mcu_fd_sc_mcu7t5v0__xnor3_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/xnor3/gf180mcu_fd_sc_mcu7t5v0__xnor3_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__xnor3_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xnor3/gf180mcu_fd_sc_mcu7t5v0__xnor3_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu7t5v0/cells/xnor3/gf180mcu_fd_sc_mcu7t5v0__xnor3_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__xor2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xor2/gf180mcu_fd_sc_mcu7t5v0__xor2_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xor2/gf180mcu_fd_sc_mcu7t5v0__xor2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__xor2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xor2/gf180mcu_fd_sc_mcu7t5v0__xor2_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xor2/gf180mcu_fd_sc_mcu7t5v0__xor2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__xor2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xor2/gf180mcu_fd_sc_mcu7t5v0__xor2_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xor2/gf180mcu_fd_sc_mcu7t5v0__xor2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__xor3_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xor3/gf180mcu_fd_sc_mcu7t5v0__xor3_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xor3/gf180mcu_fd_sc_mcu7t5v0__xor3_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__xor3_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xor3/gf180mcu_fd_sc_mcu7t5v0__xor3_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xor3/gf180mcu_fd_sc_mcu7t5v0__xor3_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu7t5v0__xor3_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xor3/gf180mcu_fd_sc_mcu7t5v0__xor3_4.gds")
-
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu7t5v0/cells/xor3/gf180mcu_fd_sc_mcu7t5v0__xor3_4.gds"
+    )
 
 
 # ── 9-track 5V standard cells ──
 
+
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__addf_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/addf/gf180mcu_fd_sc_mcu9t5v0__addf_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/addf/gf180mcu_fd_sc_mcu9t5v0__addf_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__addf_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/addf/gf180mcu_fd_sc_mcu9t5v0__addf_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/addf/gf180mcu_fd_sc_mcu9t5v0__addf_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__addf_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/addf/gf180mcu_fd_sc_mcu9t5v0__addf_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/addf/gf180mcu_fd_sc_mcu9t5v0__addf_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__addh_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/addh/gf180mcu_fd_sc_mcu9t5v0__addh_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/addh/gf180mcu_fd_sc_mcu9t5v0__addh_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__addh_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/addh/gf180mcu_fd_sc_mcu9t5v0__addh_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/addh/gf180mcu_fd_sc_mcu9t5v0__addh_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__addh_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/addh/gf180mcu_fd_sc_mcu9t5v0__addh_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/addh/gf180mcu_fd_sc_mcu9t5v0__addh_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__and2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and2/gf180mcu_fd_sc_mcu9t5v0__and2_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and2/gf180mcu_fd_sc_mcu9t5v0__and2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__and2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and2/gf180mcu_fd_sc_mcu9t5v0__and2_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and2/gf180mcu_fd_sc_mcu9t5v0__and2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__and2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and2/gf180mcu_fd_sc_mcu9t5v0__and2_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and2/gf180mcu_fd_sc_mcu9t5v0__and2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__and3_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and3/gf180mcu_fd_sc_mcu9t5v0__and3_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and3/gf180mcu_fd_sc_mcu9t5v0__and3_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__and3_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and3/gf180mcu_fd_sc_mcu9t5v0__and3_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and3/gf180mcu_fd_sc_mcu9t5v0__and3_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__and3_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and3/gf180mcu_fd_sc_mcu9t5v0__and3_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and3/gf180mcu_fd_sc_mcu9t5v0__and3_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__and4_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and4/gf180mcu_fd_sc_mcu9t5v0__and4_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and4/gf180mcu_fd_sc_mcu9t5v0__and4_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__and4_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and4/gf180mcu_fd_sc_mcu9t5v0__and4_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and4/gf180mcu_fd_sc_mcu9t5v0__and4_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__and4_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and4/gf180mcu_fd_sc_mcu9t5v0__and4_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/and4/gf180mcu_fd_sc_mcu9t5v0__and4_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__antenna() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/antenna/gf180mcu_fd_sc_mcu9t5v0__antenna.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/antenna/gf180mcu_fd_sc_mcu9t5v0__antenna.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi21_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi21/gf180mcu_fd_sc_mcu9t5v0__aoi21_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi21/gf180mcu_fd_sc_mcu9t5v0__aoi21_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi21_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi21/gf180mcu_fd_sc_mcu9t5v0__aoi21_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi21/gf180mcu_fd_sc_mcu9t5v0__aoi21_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi21_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi21/gf180mcu_fd_sc_mcu9t5v0__aoi21_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi21/gf180mcu_fd_sc_mcu9t5v0__aoi21_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi211_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi211/gf180mcu_fd_sc_mcu9t5v0__aoi211_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi211/gf180mcu_fd_sc_mcu9t5v0__aoi211_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi211_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi211/gf180mcu_fd_sc_mcu9t5v0__aoi211_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi211/gf180mcu_fd_sc_mcu9t5v0__aoi211_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi211_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi211/gf180mcu_fd_sc_mcu9t5v0__aoi211_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi211/gf180mcu_fd_sc_mcu9t5v0__aoi211_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi22_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi22/gf180mcu_fd_sc_mcu9t5v0__aoi22_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi22/gf180mcu_fd_sc_mcu9t5v0__aoi22_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi22_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi22/gf180mcu_fd_sc_mcu9t5v0__aoi22_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi22/gf180mcu_fd_sc_mcu9t5v0__aoi22_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi22_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi22/gf180mcu_fd_sc_mcu9t5v0__aoi22_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi22/gf180mcu_fd_sc_mcu9t5v0__aoi22_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi221_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi221/gf180mcu_fd_sc_mcu9t5v0__aoi221_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi221/gf180mcu_fd_sc_mcu9t5v0__aoi221_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi221_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi221/gf180mcu_fd_sc_mcu9t5v0__aoi221_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi221/gf180mcu_fd_sc_mcu9t5v0__aoi221_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi221_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi221/gf180mcu_fd_sc_mcu9t5v0__aoi221_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi221/gf180mcu_fd_sc_mcu9t5v0__aoi221_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi222_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi222/gf180mcu_fd_sc_mcu9t5v0__aoi222_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi222/gf180mcu_fd_sc_mcu9t5v0__aoi222_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi222_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi222/gf180mcu_fd_sc_mcu9t5v0__aoi222_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi222/gf180mcu_fd_sc_mcu9t5v0__aoi222_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__aoi222_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi222/gf180mcu_fd_sc_mcu9t5v0__aoi222_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/aoi222/gf180mcu_fd_sc_mcu9t5v0__aoi222_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__buf_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__buf_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_12.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__buf_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_16.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__buf_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__buf_20() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_20.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_20.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__buf_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_3.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__buf_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__buf_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_8.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/buf/gf180mcu_fd_sc_mcu9t5v0__buf_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__bufz_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__bufz_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_12.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__bufz_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_16.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__bufz_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__bufz_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_3.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__bufz_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__bufz_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_8.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/bufz/gf180mcu_fd_sc_mcu9t5v0__bufz_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkbuf_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkbuf_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_12.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkbuf_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_16.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkbuf_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkbuf_20() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_20.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_20.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkbuf_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_3.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkbuf_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkbuf_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_8.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkbuf/gf180mcu_fd_sc_mcu9t5v0__clkbuf_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_12.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_16.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_20() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_20.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_20.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_3.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_8.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/clkinv/gf180mcu_fd_sc_mcu9t5v0__clkinv_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnq/gf180mcu_fd_sc_mcu9t5v0__dffnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnq/gf180mcu_fd_sc_mcu9t5v0__dffnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnq/gf180mcu_fd_sc_mcu9t5v0__dffnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnq/gf180mcu_fd_sc_mcu9t5v0__dffnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnq/gf180mcu_fd_sc_mcu9t5v0__dffnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnq/gf180mcu_fd_sc_mcu9t5v0__dffnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffnrnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnrnq/gf180mcu_fd_sc_mcu9t5v0__dffnrnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnrnq/gf180mcu_fd_sc_mcu9t5v0__dffnrnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffnrnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnrnq/gf180mcu_fd_sc_mcu9t5v0__dffnrnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnrnq/gf180mcu_fd_sc_mcu9t5v0__dffnrnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffnrnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnrnq/gf180mcu_fd_sc_mcu9t5v0__dffnrnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnrnq/gf180mcu_fd_sc_mcu9t5v0__dffnrnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffnrsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnrsnq/gf180mcu_fd_sc_mcu9t5v0__dffnrsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnrsnq/gf180mcu_fd_sc_mcu9t5v0__dffnrsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffnrsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnrsnq/gf180mcu_fd_sc_mcu9t5v0__dffnrsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnrsnq/gf180mcu_fd_sc_mcu9t5v0__dffnrsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffnrsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnrsnq/gf180mcu_fd_sc_mcu9t5v0__dffnrsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnrsnq/gf180mcu_fd_sc_mcu9t5v0__dffnrsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffnsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnsnq/gf180mcu_fd_sc_mcu9t5v0__dffnsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnsnq/gf180mcu_fd_sc_mcu9t5v0__dffnsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffnsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnsnq/gf180mcu_fd_sc_mcu9t5v0__dffnsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnsnq/gf180mcu_fd_sc_mcu9t5v0__dffnsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffnsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnsnq/gf180mcu_fd_sc_mcu9t5v0__dffnsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffnsnq/gf180mcu_fd_sc_mcu9t5v0__dffnsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffq/gf180mcu_fd_sc_mcu9t5v0__dffq_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffq/gf180mcu_fd_sc_mcu9t5v0__dffq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffq/gf180mcu_fd_sc_mcu9t5v0__dffq_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffq/gf180mcu_fd_sc_mcu9t5v0__dffq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffq/gf180mcu_fd_sc_mcu9t5v0__dffq_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffq/gf180mcu_fd_sc_mcu9t5v0__dffq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffrnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu9t5v0__dffrnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu9t5v0__dffrnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffrnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu9t5v0__dffrnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu9t5v0__dffrnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffrnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu9t5v0__dffrnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu9t5v0__dffrnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffrsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu9t5v0__dffrsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu9t5v0__dffrsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffrsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu9t5v0__dffrsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu9t5v0__dffrsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffrsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu9t5v0__dffrsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu9t5v0__dffrsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu9t5v0__dffsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu9t5v0__dffsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu9t5v0__dffsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu9t5v0__dffsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dffsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu9t5v0__dffsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu9t5v0__dffsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/dffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dlya_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlya/gf180mcu_fd_sc_mcu9t5v0__dlya_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlya/gf180mcu_fd_sc_mcu9t5v0__dlya_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dlya_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlya/gf180mcu_fd_sc_mcu9t5v0__dlya_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlya/gf180mcu_fd_sc_mcu9t5v0__dlya_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dlya_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlya/gf180mcu_fd_sc_mcu9t5v0__dlya_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlya/gf180mcu_fd_sc_mcu9t5v0__dlya_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dlyb_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyb/gf180mcu_fd_sc_mcu9t5v0__dlyb_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyb/gf180mcu_fd_sc_mcu9t5v0__dlyb_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dlyb_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyb/gf180mcu_fd_sc_mcu9t5v0__dlyb_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyb/gf180mcu_fd_sc_mcu9t5v0__dlyb_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dlyb_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyb/gf180mcu_fd_sc_mcu9t5v0__dlyb_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyb/gf180mcu_fd_sc_mcu9t5v0__dlyb_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dlyc_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyc/gf180mcu_fd_sc_mcu9t5v0__dlyc_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyc/gf180mcu_fd_sc_mcu9t5v0__dlyc_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dlyc_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyc/gf180mcu_fd_sc_mcu9t5v0__dlyc_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyc/gf180mcu_fd_sc_mcu9t5v0__dlyc_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dlyc_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyc/gf180mcu_fd_sc_mcu9t5v0__dlyc_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyc/gf180mcu_fd_sc_mcu9t5v0__dlyc_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dlyd_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyd/gf180mcu_fd_sc_mcu9t5v0__dlyd_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyd/gf180mcu_fd_sc_mcu9t5v0__dlyd_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dlyd_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyd/gf180mcu_fd_sc_mcu9t5v0__dlyd_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyd/gf180mcu_fd_sc_mcu9t5v0__dlyd_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__dlyd_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyd/gf180mcu_fd_sc_mcu9t5v0__dlyd_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/dlyd/gf180mcu_fd_sc_mcu9t5v0__dlyd_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__endcap() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/endcap/gf180mcu_fd_sc_mcu9t5v0__endcap.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/endcap/gf180mcu_fd_sc_mcu9t5v0__endcap.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__fill_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__fill_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_16.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__fill_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__fill_32() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_32.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_32.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__fill_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__fill_64() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_64.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_64.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__fill_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_8.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fill/gf180mcu_fd_sc_mcu9t5v0__fill_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__fillcap_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fillcap/gf180mcu_fd_sc_mcu9t5v0__fillcap_16.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/fillcap/gf180mcu_fd_sc_mcu9t5v0__fillcap_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__fillcap_32() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fillcap/gf180mcu_fd_sc_mcu9t5v0__fillcap_32.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/fillcap/gf180mcu_fd_sc_mcu9t5v0__fillcap_32.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__fillcap_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fillcap/gf180mcu_fd_sc_mcu9t5v0__fillcap_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/fillcap/gf180mcu_fd_sc_mcu9t5v0__fillcap_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__fillcap_64() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fillcap/gf180mcu_fd_sc_mcu9t5v0__fillcap_64.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/fillcap/gf180mcu_fd_sc_mcu9t5v0__fillcap_64.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__fillcap_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/fillcap/gf180mcu_fd_sc_mcu9t5v0__fillcap_8.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/fillcap/gf180mcu_fd_sc_mcu9t5v0__fillcap_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__filltie() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/filltie/gf180mcu_fd_sc_mcu9t5v0__filltie.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/filltie/gf180mcu_fd_sc_mcu9t5v0__filltie.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__hold() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/hold/gf180mcu_fd_sc_mcu9t5v0__hold.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/hold/gf180mcu_fd_sc_mcu9t5v0__hold.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__icgtn_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/icgtn/gf180mcu_fd_sc_mcu9t5v0__icgtn_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/icgtn/gf180mcu_fd_sc_mcu9t5v0__icgtn_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__icgtn_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/icgtn/gf180mcu_fd_sc_mcu9t5v0__icgtn_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/icgtn/gf180mcu_fd_sc_mcu9t5v0__icgtn_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__icgtn_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/icgtn/gf180mcu_fd_sc_mcu9t5v0__icgtn_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/icgtn/gf180mcu_fd_sc_mcu9t5v0__icgtn_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__icgtp_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/icgtp/gf180mcu_fd_sc_mcu9t5v0__icgtp_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/icgtp/gf180mcu_fd_sc_mcu9t5v0__icgtp_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__icgtp_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/icgtp/gf180mcu_fd_sc_mcu9t5v0__icgtp_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/icgtp/gf180mcu_fd_sc_mcu9t5v0__icgtp_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__icgtp_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/icgtp/gf180mcu_fd_sc_mcu9t5v0__icgtp_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/icgtp/gf180mcu_fd_sc_mcu9t5v0__icgtp_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_12.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_16.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_20() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_20.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_20.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_3.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__clkinv_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_8.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__clkinv_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__inv_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__inv_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_12.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__inv_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_16.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__inv_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__inv_20() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_20.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_20.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__inv_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_3.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__inv_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__inv_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_8.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/inv/gf180mcu_fd_sc_mcu9t5v0__inv_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__invz_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__invz_12() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_12.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_12.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__invz_16() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_16.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_16.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__invz_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__invz_3() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_3.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_3.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__invz_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__invz_8() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_8.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/invz/gf180mcu_fd_sc_mcu9t5v0__invz_8.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__latq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latq/gf180mcu_fd_sc_mcu9t5v0__latq_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latq/gf180mcu_fd_sc_mcu9t5v0__latq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__latq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latq/gf180mcu_fd_sc_mcu9t5v0__latq_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latq/gf180mcu_fd_sc_mcu9t5v0__latq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__latq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latq/gf180mcu_fd_sc_mcu9t5v0__latq_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latq/gf180mcu_fd_sc_mcu9t5v0__latq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__latrnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latrnq/gf180mcu_fd_sc_mcu9t5v0__latrnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/latrnq/gf180mcu_fd_sc_mcu9t5v0__latrnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__latrnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latrnq/gf180mcu_fd_sc_mcu9t5v0__latrnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/latrnq/gf180mcu_fd_sc_mcu9t5v0__latrnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__latrnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latrnq/gf180mcu_fd_sc_mcu9t5v0__latrnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/latrnq/gf180mcu_fd_sc_mcu9t5v0__latrnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__latrsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latrsnq/gf180mcu_fd_sc_mcu9t5v0__latrsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/latrsnq/gf180mcu_fd_sc_mcu9t5v0__latrsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__latrsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latrsnq/gf180mcu_fd_sc_mcu9t5v0__latrsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/latrsnq/gf180mcu_fd_sc_mcu9t5v0__latrsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__latrsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latrsnq/gf180mcu_fd_sc_mcu9t5v0__latrsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/latrsnq/gf180mcu_fd_sc_mcu9t5v0__latrsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__latsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latsnq/gf180mcu_fd_sc_mcu9t5v0__latsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/latsnq/gf180mcu_fd_sc_mcu9t5v0__latsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__latsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latsnq/gf180mcu_fd_sc_mcu9t5v0__latsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/latsnq/gf180mcu_fd_sc_mcu9t5v0__latsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__latsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/latsnq/gf180mcu_fd_sc_mcu9t5v0__latsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/latsnq/gf180mcu_fd_sc_mcu9t5v0__latsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__mux2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/mux2/gf180mcu_fd_sc_mcu9t5v0__mux2_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/mux2/gf180mcu_fd_sc_mcu9t5v0__mux2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__mux2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/mux2/gf180mcu_fd_sc_mcu9t5v0__mux2_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/mux2/gf180mcu_fd_sc_mcu9t5v0__mux2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__mux2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/mux2/gf180mcu_fd_sc_mcu9t5v0__mux2_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/mux2/gf180mcu_fd_sc_mcu9t5v0__mux2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__mux4_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/mux4/gf180mcu_fd_sc_mcu9t5v0__mux4_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/mux4/gf180mcu_fd_sc_mcu9t5v0__mux4_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__mux4_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/mux4/gf180mcu_fd_sc_mcu9t5v0__mux4_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/mux4/gf180mcu_fd_sc_mcu9t5v0__mux4_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__mux4_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/mux4/gf180mcu_fd_sc_mcu9t5v0__mux4_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/mux4/gf180mcu_fd_sc_mcu9t5v0__mux4_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nand2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nand2/gf180mcu_fd_sc_mcu9t5v0__nand2_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/nand2/gf180mcu_fd_sc_mcu9t5v0__nand2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nand2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nand2/gf180mcu_fd_sc_mcu9t5v0__nand2_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/nand2/gf180mcu_fd_sc_mcu9t5v0__nand2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nand2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nand2/gf180mcu_fd_sc_mcu9t5v0__nand2_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/nand2/gf180mcu_fd_sc_mcu9t5v0__nand2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nand3_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nand3/gf180mcu_fd_sc_mcu9t5v0__nand3_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/nand3/gf180mcu_fd_sc_mcu9t5v0__nand3_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nand3_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nand3/gf180mcu_fd_sc_mcu9t5v0__nand3_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/nand3/gf180mcu_fd_sc_mcu9t5v0__nand3_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nand3_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nand3/gf180mcu_fd_sc_mcu9t5v0__nand3_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/nand3/gf180mcu_fd_sc_mcu9t5v0__nand3_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nand4_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nand4/gf180mcu_fd_sc_mcu9t5v0__nand4_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/nand4/gf180mcu_fd_sc_mcu9t5v0__nand4_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nand4_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nand4/gf180mcu_fd_sc_mcu9t5v0__nand4_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/nand4/gf180mcu_fd_sc_mcu9t5v0__nand4_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nand4_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nand4/gf180mcu_fd_sc_mcu9t5v0__nand4_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/nand4/gf180mcu_fd_sc_mcu9t5v0__nand4_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nor2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor2/gf180mcu_fd_sc_mcu9t5v0__nor2_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor2/gf180mcu_fd_sc_mcu9t5v0__nor2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nor2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor2/gf180mcu_fd_sc_mcu9t5v0__nor2_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor2/gf180mcu_fd_sc_mcu9t5v0__nor2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nor2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor2/gf180mcu_fd_sc_mcu9t5v0__nor2_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor2/gf180mcu_fd_sc_mcu9t5v0__nor2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nor3_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor3/gf180mcu_fd_sc_mcu9t5v0__nor3_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor3/gf180mcu_fd_sc_mcu9t5v0__nor3_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nor3_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor3/gf180mcu_fd_sc_mcu9t5v0__nor3_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor3/gf180mcu_fd_sc_mcu9t5v0__nor3_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nor3_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor3/gf180mcu_fd_sc_mcu9t5v0__nor3_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor3/gf180mcu_fd_sc_mcu9t5v0__nor3_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nor4_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor4/gf180mcu_fd_sc_mcu9t5v0__nor4_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor4/gf180mcu_fd_sc_mcu9t5v0__nor4_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nor4_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor4/gf180mcu_fd_sc_mcu9t5v0__nor4_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor4/gf180mcu_fd_sc_mcu9t5v0__nor4_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__nor4_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor4/gf180mcu_fd_sc_mcu9t5v0__nor4_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/nor4/gf180mcu_fd_sc_mcu9t5v0__nor4_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai21_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai21/gf180mcu_fd_sc_mcu9t5v0__oai21_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai21/gf180mcu_fd_sc_mcu9t5v0__oai21_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai21_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai21/gf180mcu_fd_sc_mcu9t5v0__oai21_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai21/gf180mcu_fd_sc_mcu9t5v0__oai21_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai21_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai21/gf180mcu_fd_sc_mcu9t5v0__oai21_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai21/gf180mcu_fd_sc_mcu9t5v0__oai21_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai211_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai211/gf180mcu_fd_sc_mcu9t5v0__oai211_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai211/gf180mcu_fd_sc_mcu9t5v0__oai211_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai211_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai211/gf180mcu_fd_sc_mcu9t5v0__oai211_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai211/gf180mcu_fd_sc_mcu9t5v0__oai211_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai211_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai211/gf180mcu_fd_sc_mcu9t5v0__oai211_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai211/gf180mcu_fd_sc_mcu9t5v0__oai211_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai22_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai22/gf180mcu_fd_sc_mcu9t5v0__oai22_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai22/gf180mcu_fd_sc_mcu9t5v0__oai22_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai22_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai22/gf180mcu_fd_sc_mcu9t5v0__oai22_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai22/gf180mcu_fd_sc_mcu9t5v0__oai22_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai22_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai22/gf180mcu_fd_sc_mcu9t5v0__oai22_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai22/gf180mcu_fd_sc_mcu9t5v0__oai22_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai221_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai221/gf180mcu_fd_sc_mcu9t5v0__oai221_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai221/gf180mcu_fd_sc_mcu9t5v0__oai221_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai221_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai221/gf180mcu_fd_sc_mcu9t5v0__oai221_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai221/gf180mcu_fd_sc_mcu9t5v0__oai221_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai221_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai221/gf180mcu_fd_sc_mcu9t5v0__oai221_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai221/gf180mcu_fd_sc_mcu9t5v0__oai221_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai222_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai222/gf180mcu_fd_sc_mcu9t5v0__oai222_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai222/gf180mcu_fd_sc_mcu9t5v0__oai222_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai222_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai222/gf180mcu_fd_sc_mcu9t5v0__oai222_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai222/gf180mcu_fd_sc_mcu9t5v0__oai222_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai222_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai222/gf180mcu_fd_sc_mcu9t5v0__oai222_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai222/gf180mcu_fd_sc_mcu9t5v0__oai222_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai31_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai31/gf180mcu_fd_sc_mcu9t5v0__oai31_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai31/gf180mcu_fd_sc_mcu9t5v0__oai31_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai31_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai31/gf180mcu_fd_sc_mcu9t5v0__oai31_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai31/gf180mcu_fd_sc_mcu9t5v0__oai31_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai31_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai31/gf180mcu_fd_sc_mcu9t5v0__oai31_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai31/gf180mcu_fd_sc_mcu9t5v0__oai31_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai32_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai32/gf180mcu_fd_sc_mcu9t5v0__oai32_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai32/gf180mcu_fd_sc_mcu9t5v0__oai32_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai32_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai32/gf180mcu_fd_sc_mcu9t5v0__oai32_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai32/gf180mcu_fd_sc_mcu9t5v0__oai32_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai32_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai32/gf180mcu_fd_sc_mcu9t5v0__oai32_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai32/gf180mcu_fd_sc_mcu9t5v0__oai32_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai33_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai33/gf180mcu_fd_sc_mcu9t5v0__oai33_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai33/gf180mcu_fd_sc_mcu9t5v0__oai33_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai33_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai33/gf180mcu_fd_sc_mcu9t5v0__oai33_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai33/gf180mcu_fd_sc_mcu9t5v0__oai33_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__oai33_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/oai33/gf180mcu_fd_sc_mcu9t5v0__oai33_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/oai33/gf180mcu_fd_sc_mcu9t5v0__oai33_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__or2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or2/gf180mcu_fd_sc_mcu9t5v0__or2_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or2/gf180mcu_fd_sc_mcu9t5v0__or2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__or2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or2/gf180mcu_fd_sc_mcu9t5v0__or2_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or2/gf180mcu_fd_sc_mcu9t5v0__or2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__or2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or2/gf180mcu_fd_sc_mcu9t5v0__or2_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or2/gf180mcu_fd_sc_mcu9t5v0__or2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__or3_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or3/gf180mcu_fd_sc_mcu9t5v0__or3_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or3/gf180mcu_fd_sc_mcu9t5v0__or3_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__or3_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or3/gf180mcu_fd_sc_mcu9t5v0__or3_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or3/gf180mcu_fd_sc_mcu9t5v0__or3_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__or3_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or3/gf180mcu_fd_sc_mcu9t5v0__or3_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or3/gf180mcu_fd_sc_mcu9t5v0__or3_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__or4_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or4/gf180mcu_fd_sc_mcu9t5v0__or4_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or4/gf180mcu_fd_sc_mcu9t5v0__or4_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__or4_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or4/gf180mcu_fd_sc_mcu9t5v0__or4_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or4/gf180mcu_fd_sc_mcu9t5v0__or4_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__or4_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or4/gf180mcu_fd_sc_mcu9t5v0__or4_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/or4/gf180mcu_fd_sc_mcu9t5v0__or4_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__tieh() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/tieh/gf180mcu_fd_sc_mcu9t5v0__tieh.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/tieh/gf180mcu_fd_sc_mcu9t5v0__tieh.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__tiel() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/tiel/gf180mcu_fd_sc_mcu9t5v0__tiel.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/tiel/gf180mcu_fd_sc_mcu9t5v0__tiel.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__xnor2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xnor2/gf180mcu_fd_sc_mcu9t5v0__xnor2_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/xnor2/gf180mcu_fd_sc_mcu9t5v0__xnor2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__xnor2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xnor2/gf180mcu_fd_sc_mcu9t5v0__xnor2_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/xnor2/gf180mcu_fd_sc_mcu9t5v0__xnor2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__xnor2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xnor2/gf180mcu_fd_sc_mcu9t5v0__xnor2_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/xnor2/gf180mcu_fd_sc_mcu9t5v0__xnor2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__xnor3_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xnor3/gf180mcu_fd_sc_mcu9t5v0__xnor3_1.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/xnor3/gf180mcu_fd_sc_mcu9t5v0__xnor3_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__xnor3_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xnor3/gf180mcu_fd_sc_mcu9t5v0__xnor3_2.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/xnor3/gf180mcu_fd_sc_mcu9t5v0__xnor3_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__xnor3_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xnor3/gf180mcu_fd_sc_mcu9t5v0__xnor3_4.gds")
+    return _import_gds(
+        _SRC
+        / "gf180mcu_fd_sc_mcu9t5v0/cells/xnor3/gf180mcu_fd_sc_mcu9t5v0__xnor3_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__xor2_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xor2/gf180mcu_fd_sc_mcu9t5v0__xor2_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xor2/gf180mcu_fd_sc_mcu9t5v0__xor2_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__xor2_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xor2/gf180mcu_fd_sc_mcu9t5v0__xor2_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xor2/gf180mcu_fd_sc_mcu9t5v0__xor2_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__xor2_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xor2/gf180mcu_fd_sc_mcu9t5v0__xor2_4.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xor2/gf180mcu_fd_sc_mcu9t5v0__xor2_4.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__xor3_1() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xor3/gf180mcu_fd_sc_mcu9t5v0__xor3_1.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xor3/gf180mcu_fd_sc_mcu9t5v0__xor3_1.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__xor3_2() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xor3/gf180mcu_fd_sc_mcu9t5v0__xor3_2.gds")
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xor3/gf180mcu_fd_sc_mcu9t5v0__xor3_2.gds"
+    )
 
 
 @gf.cell
 def gf180mcu_fd_sc_mcu9t5v0__xor3_4() -> gf.Component:
-    return _import_gds(_SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xor3/gf180mcu_fd_sc_mcu9t5v0__xor3_4.gds")
-
+    return _import_gds(
+        _SRC / "gf180mcu_fd_sc_mcu9t5v0/cells/xor3/gf180mcu_fd_sc_mcu9t5v0__xor3_4.gds"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
   "pytest-github-actions-annotate-failures",
   "towncrier"
 ]
-docs = ["jupytext", "matplotlib", "jupyter-book>=0.15.1,<2.2"]
+docs = ["jupytext", "matplotlib", "jupyter-book==1.0.3"]
 tests = ["pytest", "pytest-cov"]
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ docs = ["jupytext", "matplotlib", "jupyter-book>=0.15.1,<2.2"]
 tests = ["pytest", "pytest-cov"]
 
 [tool.codespell]
-ignore-words-list = "inout,ags,souce"
+ignore-words-list = "inout,ags,souce,te,hepl,deivces,accomodate"
+skip = "*.lock,*.svg,*.gds,*.oas,*.lib,*.tcl,scripts/magic/*,tests/test_components/test_pdk_settings_*.yml"
 
 [tool.gdsfactoryplus.pdk]
 name = "gf180mcu"
@@ -69,7 +70,9 @@ ignore = [
   "C901",  # too complex
   "B905",  # `zip()` without an explicit `strict=` parameter
   "C408",  # C408 Unnecessary `dict` call (rewrite as a literal)
-  'B006'
+  'B006',
+  "RUF002",  # ambiguous unicode in docstrings (× and − intentional for EE notation)
+  "RUF003"  # ambiguous unicode in comments (same)
 ]
 select = [
   "B",  # flake8-bugbear
@@ -86,7 +89,14 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+# PDK cell files keep intermediate rule-lookups as named locals for parity
+# with the upstream spec; `l` = gate length (standard EE symbol).
+"gf180mcu/cells/*.py" = ["F841", "E741", "RUF034"]
 "gf180mcu/cells/__init__.py" = ["F403"]
+# Auto-generated wrappers for 498 standard cells — duplicate defs across 7t/9t
+# libraries are by design and unused locals don't apply.
+"gf180mcu/logic/__init__.py" = ["F811", "F841", "F401"]
+"tests/*.py" = ["E741", "PERF401"]
 
 [tool.setuptools.package-data]
 "*" = ["*.csv", "*.yaml", "*.yml", "*.gds", "*.lyp", "*.oas", "*.lyt", "*.dat", "*.nc", "*.svg", '*.GDS', "*.json", "*.txt"]

--- a/scripts/magic/gf180mcu_generators.tcl
+++ b/scripts/magic/gf180mcu_generators.tcl
@@ -85,7 +85,7 @@ namespace eval gf180mcu {
 
 proc gf180mcu::addtechmenu {framename} {
    global Winopts Opts
-   
+
    # Check for difference between magic 8.1.125 and earlier, and 8.1.126 and later
    if {[catch {${framename}.titlebar cget -height}]} {
       set layoutframe ${framename}.pane.top
@@ -131,8 +131,8 @@ proc gf180mcu::addtechmenu {framename} {
 
    magic::add_toolkit_menu $layoutframe "Devices 2" pdk2
 
-   magic::add_toolkit_command $layoutframe "ppolyf_s        - 7 Ohm/sq " "magic::gencell gf180mcu::ppolyf_s" pdk2 
-   magic::add_toolkit_command $layoutframe "npolyf_s        - 7 Ohm/sq " "magic::gencell gf180mcu::ppolyf_s" pdk2 
+   magic::add_toolkit_command $layoutframe "ppolyf_s        - 7 Ohm/sq " "magic::gencell gf180mcu::ppolyf_s" pdk2
+   magic::add_toolkit_command $layoutframe "npolyf_s        - 7 Ohm/sq " "magic::gencell gf180mcu::ppolyf_s" pdk2
    magic::add_toolkit_command $layoutframe "nplus_u   (3.3V) -  85 Ohm/sq " "magic::gencell gf180mcu::nplus_u" pdk2
    magic::add_toolkit_command $layoutframe "pplus_u   (3.3V) - 128 Ohm/sq " "magic::gencell gf180mcu::pplus_u" pdk2
    magic::add_toolkit_command $layoutframe "nplus_u  (6.0V) -  85 Ohm/sq " "magic::gencell gf180mcu::nplus_u_6p0" pdk2
@@ -568,7 +568,7 @@ proc gf180mcu::diode_dialog {device parameters} {
     if {[dict exists $parameters compatible]} {
        set sellist [dict get $parameters compatible]
        # Reserved word "gencell" has special behavior to change the
-       # underlying device type 
+       # underlying device type
        dict set parameters gencell $device
        magic::add_selectlist gencell "Device type" $sellist $parameters
     }
@@ -641,14 +641,14 @@ proc gf180mcu::diode_check {parameters} {
 
     # Normalize distance units to microns
     set l [magic::spice2float $l]
-    set l [magic::3digitpastdecimal $l] 
+    set l [magic::3digitpastdecimal $l]
     set w [magic::spice2float $w]
-    set w [magic::3digitpastdecimal $w] 
+    set w [magic::3digitpastdecimal $w]
 
     set area [magic::spice2float $area]
-    set area [magic::3digitpastdecimal $area] 
+    set area [magic::3digitpastdecimal $area]
     set peri [magic::spice2float $peri]
-    set peri [magic::3digitpastdecimal $peri] 
+    set peri [magic::3digitpastdecimal $peri]
 
     if {$l == 0} {
         # Calculate L from W and area
@@ -662,11 +662,11 @@ proc gf180mcu::diode_check {parameters} {
     if {$w < $wmin} {
 	puts stderr "Diode width must be >= $wmin"
 	dict set parameters w $wmin
-    } 
+    }
     if {$l < $lmin} {
 	puts stderr "Diode length must be >= $lmin"
 	dict set parameters l $lmin
-    } 
+    }
     # Calculate area and perimeter from L and W
     set area [expr ($l * $w)]
     dict set parameters area [magic::float2spice $area]
@@ -960,7 +960,7 @@ proc gf180mcu::diode_nd2ps_03v3_draw {parameters} {
     ]
     set drawdict [dict merge $gf180mcu::ruleset $newdict $parameters]
     return [gf180mcu::diode_draw $drawdict]
-} 
+}
 
 #----------------------------------------------------------------
 
@@ -1102,7 +1102,7 @@ proc gf180mcu::cap_recalc {field parameters} {
 #
 #  wmin   Minimum allowed width
 #  lmin   Minimum allowed length
-#  dc     Area to remove to calculated area 
+#  dc     Area to remove to calculated area
 #----------------------------------------------------------------
 
 #----------------------------------------------------------------
@@ -1688,9 +1688,9 @@ proc gf180mcu::cap_check {parameters} {
 
     # Normalize distance units to microns
     set l [magic::spice2float $l]
-    set l [magic::3digitpastdecimal $l] 
+    set l [magic::3digitpastdecimal $l]
     set w [magic::spice2float $w]
-    set w [magic::3digitpastdecimal $w] 
+    set w [magic::3digitpastdecimal $w]
 
     set val   [magic::spice2float $val]
     set carea [magic::spice2float $carea]
@@ -1719,22 +1719,22 @@ proc gf180mcu::cap_check {parameters} {
 	puts stderr "Capacitor width must be >= $wmin"
 	dict set parameters w $wmin
 	set w $wmin
-    } 
+    }
     if {$l < $lmin} {
 	puts stderr "Capacitor length must be >= $lmin"
 	dict set parameters l $lmin
 	set l $lmin
-    } 
+    }
     if {($wmax > 0) && ($w > $wmax)} {
 	puts stderr "Capacitor width must be <= $wmax"
 	dict set parameters w $wmax
 	set w $wmax
-    } 
+    }
     if {($lmax > 0) && ($l > $lmax)} {
 	puts stderr "Capacitor length must be <= $lmax"
 	dict set parameters l $lmax
 	set l $lmax
-    } 
+    }
     # Calculate value from L and W
     set cval [expr ($l * $w * $carea + 2 * ($l + $w) * $cperi - 4 * $dc)]
     dict set parameters val [magic::float2spice $cval]
@@ -1833,7 +1833,7 @@ proc gf180mcu::npolyf_s_defaults {} {
 
 #----------------------------------------------------------------
 # nplus_u: Specify all user-editable default values and those
-# needed by nplus_u_check 
+# needed by nplus_u_check
 #----------------------------------------------------------------
 
 proc gf180mcu::nplus_u_defaults {} {
@@ -1939,7 +1939,7 @@ proc gf180mcu::ppolyf_u_1k_6p0_defaults {} {
 		compatible {ppolyf_u_1k ppolyf_u_1k_6p0}}
 }
 #endif (HRPOLY1K)
- 
+
 #----------------------------------------------------------------
 # resistor: Conversion from SPICE netlist parameters to toolkit
 #----------------------------------------------------------------
@@ -2052,7 +2052,7 @@ proc gf180mcu::ppolyf_u_1k_6p0_convert {parameters} {
 
 proc gf180mcu::res_dialog {device parameters} {
     # Editable fields:      w, l, t, nx, m, val
-    # Checked fields:  
+    # Checked fields:
 
     magic::add_entry val "Value (ohms)" $parameters
     if {[dict exists $parameters snake]} {
@@ -2070,7 +2070,7 @@ proc gf180mcu::res_dialog {device parameters} {
     if {[dict exists $parameters compatible]} {
        set sellist [dict get $parameters compatible]
        # Reserved word "gencell" has special behavior to change the
-       # underlying device type 
+       # underlying device type
        dict set parameters gencell $device
        magic::add_selectlist gencell "Device type" $sellist $parameters
     }
@@ -3057,7 +3057,7 @@ proc gf180mcu::res_check {device parameters} {
     if {$w < $wmin} {
 	puts stderr "Resistor width must be >= $wmin um"
 	dict set parameters w $wmin
-    } 
+    }
     # Val and W specified - no L
     if {$l == 0}  {
    	set l [expr ($w - $dw) * $val / $rho]
@@ -3079,15 +3079,15 @@ proc gf180mcu::res_check {device parameters} {
     if {$l < $lmin} {
 	puts stderr "Resistor length must be >= $lmin um"
 	dict set parameters l $lmin
-    } 
+    }
     if {$nx < 1} {
 	puts stderr "X repeat must be >= 1"
 	dict set parameters nx 1
-    } 
+    }
     if {$m < 1} {
 	puts stderr "Y repeat must be >= 1"
 	dict set parameters m 1
-    } 
+    }
 
     # Snake resistors cannot have width greater than length
     if {$snake == 1} {
@@ -3500,7 +3500,7 @@ proc gf180mcu::mos_dialog {device parameters} {
     if {[dict exists $parameters compatible]} {
        set sellist [dict get $parameters compatible]
        # Reserved word "gencell" has special behavior to change the
-       # underlying device type 
+       # underlying device type
        dict set parameters gencell $device
        magic::add_selectlist gencell "Device type" $sellist $parameters
     }
@@ -4163,7 +4163,7 @@ proc gf180mcu::mos_draw {parameters} {
     }
 
     if {($guard != 0)} {
-        # Somewhat tricky. . . if the width is small and the diffusion is 
+        # Somewhat tricky. . . if the width is small and the diffusion is
         # a dogbone, and the top or bottom poly contact is missing, then
         # the spacing to the guard ring may be limited by diffusion spacing, not
         # poly to diffusion.
@@ -4558,9 +4558,9 @@ proc gf180mcu::mos_check {parameters} {
     }
 
     # Normalize distance units to microns
-    set l [magic::spice2float $l] 
+    set l [magic::spice2float $l]
     set l [magic::3digitpastdecimal $l]
-    set w [magic::spice2float $w] 
+    set w [magic::spice2float $w]
     set w [magic::3digitpastdecimal $w]
 
     # nf, m must be integer
@@ -4585,24 +4585,24 @@ proc gf180mcu::mos_check {parameters} {
     if {$l < $lmin} {
 	puts stderr "Mos length must be >= $lmin um"
         dict set parameters l $lmin
-    } 
+    }
     if {($lmax > 0) && ($l > $lmax)} {
 	puts stderr "MOS length must be <= $lmax"
 	dict set parameters l $lmax
 	set l $lmax
-    } 
+    }
     if {$w < $wmin} {
 	puts stderr "Mos width must be >= $wmin um"
         dict set parameters w $wmin
-    } 
+    }
     if {$nf < 1} {
 	puts stderr "NF must be >= 1"
         dict set parameters nf 1
-    } 
+    }
     if {$m < 1} {
 	puts stderr "M must be >= 1"
         dict set parameters m 1
-    } 
+    }
     if {$diffcov < 20 } {
 	puts stderr "Diffusion contact coverage must be at least 20%"
         dict set parameters diffcov 20
@@ -4874,7 +4874,7 @@ proc gf180mcu::fixed_dialog {parameters} {
     if [dict exists $parameters pitchx] {
 	set pitchux [magic::i2u $pitchx]
 	set stepux [magic::spice2float $xstep]
-        set deltax [magic::3digitpastdecimal [expr $pitchux - $stepux]] 
+        set deltax [magic::3digitpastdecimal [expr $pitchux - $stepux]]
         # An array size 1 should not cause deltax to go negative
 	if {$deltax < 0.0} {set deltax 0.0}
 	dict set parameters deltax $deltax
@@ -4882,7 +4882,7 @@ proc gf180mcu::fixed_dialog {parameters} {
     if [dict exists $parameters pitchy] {
 	set pitchuy [magic::i2u $pitchy]
 	set stepuy [magic::spice2float $ystep]
-        set deltay [magic::3digitpastdecimal [expr $pitchuy - $stepuy]] 
+        set deltay [magic::3digitpastdecimal [expr $pitchuy - $stepuy]]
         # An array size 1 should not cause deltay to go negative
 	if {$deltay < 0.0} {set deltay 0.0}
 	dict set parameters deltay $deltay
@@ -4957,10 +4957,10 @@ proc gf180mcu::fixed_draw {devname parameters} {
     # Instantiate the cell.  The name corresponds to the cell in the primdev directory.
     set instname [getcell ${devname}]
 
-    set deltax [magic::spice2float $deltax] 
-    set deltay [magic::spice2float $deltay] 
-    set xstep [magic::spice2float $xstep] 
-    set ystep [magic::spice2float $ystep] 
+    set deltax [magic::spice2float $deltax]
+    set deltay [magic::spice2float $deltay]
+    set xstep [magic::spice2float $xstep]
+    set ystep [magic::spice2float $ystep]
 
     # Array stepping
     if {$nx > 1 || $ny > 1} {
@@ -5034,9 +5034,9 @@ proc gf180mcu::fixed_check {parameters} {
     }
 
     # Normalize distance units to microns
-    set deltax [magic::spice2float $deltax -1] 
+    set deltax [magic::spice2float $deltax -1]
     set deltax [magic::3digitpastdecimal $deltax]
-    set deltay [magic::spice2float $deltay -1] 
+    set deltay [magic::spice2float $deltay -1]
     set deltay [magic::3digitpastdecimal $deltay]
 
     # nx, ny must be integer
@@ -5115,5 +5115,3 @@ proc gf180mcu::pnp_10p00x10p00_check {parameters} {
 proc gf180mcu::pnp_10p00x00p42_check {parameters} {
     return [gf180mcu::fixed_check $parameters]
 }
-
-

--- a/tests/test_xor.py
+++ b/tests/test_xor.py
@@ -12,16 +12,17 @@ import json
 import pathlib
 import tempfile
 
-import klayout.db as kdb
 import pytest
+
+import klayout.db as kdb
 
 # ---------------------------------------------------------------------------
 # Skip layers: label layers and boundary markers
 # ---------------------------------------------------------------------------
 
 SKIP_LAYERS = {
-    (0, 0),      # empty/context
-    (235, 4),    # prBoundary
+    (0, 0),  # empty/context
+    (235, 4),  # prBoundary
 }
 
 # Skip any datatype 5 (label layers) dynamically in xor_gds_files
@@ -139,6 +140,7 @@ def test_xor(device_name: str, params: dict, cell_module: str) -> None:
     if cell_fn is None:
         try:
             import gf180mcu
+
             fn = gf180mcu._cells.get(cell_fn_name)
             if fn and callable(fn):
                 cell_fn = fn
@@ -153,8 +155,10 @@ def test_xor(device_name: str, params: dict, cell_module: str) -> None:
     try:
         sig = inspect.signature(cell_fn)
         accepted = {
-            k for k, p in sig.parameters.items()
-            if p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+            k
+            for k, p in sig.parameters.items()
+            if p.kind
+            not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
         }
     except (ValueError, TypeError):
         accepted = set(all_params.keys())
@@ -177,8 +181,7 @@ def test_xor(device_name: str, params: dict, cell_module: str) -> None:
         if failures:
             lines = [f"  ({l},{d}): {msg}" for (l, d), msg in sorted(failures.items())]
             raise AssertionError(
-                f"XOR differences for {device_name} with {params}:\n"
-                + "\n".join(lines)
+                f"XOR differences for {device_name} with {params}:\n" + "\n".join(lines)
             )
     finally:
         run_gds.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- Syncs `.github/workflows/pages.yml` and `.github/dependabot.yml` from [doplaydo/pdk-ci-workflow#117](https://github.com/doplaydo/pdk-ci-workflow/pull/117)
- `deploy-docs` now runs inline in the caller (reusable workflow could not satisfy `workflow_call` + `environment` + per-job `permissions`, causing `startup_failure` with zero logs)
- `actions/deploy-pages` added to dependabot ignore list — the SHA is pinned in the template and kept in sync by `check_template_drift.py`, so bumps here would churn

## Test plan
- [ ] Verify `Build docs` workflow runs without `startup_failure`
- [ ] On merge to `main`, confirm docs deploy to GitHub Pages

## Summary by Sourcery

Inline the docs deployment step into the pages workflow and align automation config with the upstream template.

CI:
- Add a deploy-docs job to the pages workflow to publish GitHub Pages directly from this repository.
- Update Dependabot configuration to ignore actions/deploy-pages updates, delegating version management to the shared template.