### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,28 +2,46 @@
 
 <!-- towncrier release notes start -->
 
-## [0.5.0](https://github.com/gdsfactory/gf180mcu/releases/tag/v0.5.0) - 2026-03-09
+## [1.0.0](https://github.com/gdsfactory/gf180mcu/releases/tag/v1.0.0) - 2026-04-27
 
-- Maintenance
-    - fix docs [#35](https://github.com/gdsfactory/gf180/pull/35)
-    - update gdsfactory9.18.1 [#26](https://github.com/gdsfactory/gf180/pull/26)
-    - Bump astral-sh/setup-uv from 5 to 7 [#33](https://github.com/gdsfactory/gf180/pull/33)
-    - Bump actions/upload-pages-artifact from 3 to 4 [#15](https://github.com/gdsfactory/gf180/pull/15)
-    - Bump actions/checkout from 4 to 5 [#16](https://github.com/gdsfactory/gf180/pull/16)
-    - add more tests [#44](https://github.com/gdsfactory/gf180/pull/44)
-    - add missing pins [#37](https://github.com/gdsfactory/gf180/pull/37)
-    - add logo [#36](https://github.com/gdsfactory/gf180/pull/36)
-    - add samples [#27](https://github.com/gdsfactory/gf180/pull/27)
-- Documentation
-    - update gdsfactory to 9.39.0 [#65](https://github.com/gdsfactory/gf180/pull/65)
-    - add more tests [#44](https://github.com/gdsfactory/gf180/pull/44)
-    - add samples [#27](https://github.com/gdsfactory/gf180/pull/27)
-- Dependency Updates
-    - Bump astral-sh/setup-uv from 5 to 7 [#33](https://github.com/gdsfactory/gf180/pull/33)
-    - Bump actions/upload-pages-artifact from 3 to 4 [#15](https://github.com/gdsfactory/gf180/pull/15)
-    - Bump actions/checkout from 4 to 5 [#16](https://github.com/gdsfactory/gf180/pull/16)
-    - update gdsfactory9.18.1 [#26](https://github.com/gdsfactory/gf180/pull/26)
-    - better type annotations [#19](https://github.com/gdsfactory/gf180/pull/19)
+First stable release. Marks API parity with the upstream Magic Tcl pcell
+generators and a stable public surface for downstream tools.
+
+### Breaking
+
+- Refactor electrical pcells for Magic parity ([#91](https://github.com/gdsfactory/gf180mcu/pull/91))
+  - Ports the Magic Tcl primitive generators (FETs, BJTs, diodes, capacitors, resistors, guard rings) to Python with XOR-validated parity against reference GDS.
+  - Restructures cell modules under `gf180mcu/cells/`, adds `gf180mcu/logic` and `gf180mcu/fixed` collections.
+  - Ports missing KLayout diode variants `nw2ps`, `pw2dw`, `dw2ps`, `sc_diode`.
+- VLSIR-based netlisting support ([#51](https://github.com/gdsfactory/gf180mcu/pull/51)).
+- Layer-stack overlap fixes + interdig cell rework ([#81](https://github.com/gdsfactory/gf180mcu/pull/81)).
+
+### New
+
+- `@cell` type tags on all components ([#94](https://github.com/gdsfactory/gf180mcu/pull/94)).
+- DRC workflow + numeric DRC badge ([#78](https://github.com/gdsfactory/gf180mcu/pull/78), [#79](https://github.com/gdsfactory/gf180mcu/pull/79)).
+- Metric badge workflows + README dashboard ([#92](https://github.com/gdsfactory/gf180mcu/pull/92)).
+- Auto-label PDK workflow ([#103](https://github.com/gdsfactory/gf180mcu/pull/103)).
+- Issue auto-label CI ([#59](https://github.com/gdsfactory/gf180mcu/pull/59)).
+- Add missing pins ([#37](https://github.com/gdsfactory/gf180mcu/pull/37)).
+
+### Fixes
+
+- Activate PDK via sphinx extension instead of package import ([#99](https://github.com/gdsfactory/gf180mcu/pull/99)).
+- Hide private repo links from public docs ([#77](https://github.com/gdsfactory/gf180mcu/pull/77)).
+- LICENSE clarifications ([#97](https://github.com/gdsfactory/gf180mcu/pull/97)).
+
+### Maintenance
+
+- Sync drift-enforced workflow templates from upstream (`pages.yml`, `dependabot.yml`, `release-drafter.yml`, `test_code.yml`, `issue.yml`, `claude-pr-review.yml`) ([#96](https://github.com/gdsfactory/gf180mcu/pull/96), [#98](https://github.com/gdsfactory/gf180mcu/pull/98)).
+- Centralize CI workflows ([#75](https://github.com/gdsfactory/gf180mcu/pull/75)).
+- Switch dependabot to `uv` ecosystem with cooldown ([#80](https://github.com/gdsfactory/gf180mcu/pull/80), [#86](https://github.com/gdsfactory/gf180mcu/pull/86)).
+- Dependabot interval to monthly + ignore doplaydo actions ([#70](https://github.com/gdsfactory/gf180mcu/pull/70), [#73](https://github.com/gdsfactory/gf180mcu/pull/73)).
+- Bump `gdsfactory` to `<9.40.2` ([#89](https://github.com/gdsfactory/gf180mcu/pull/89), [#65](https://github.com/gdsfactory/gf180mcu/pull/65)).
+- Python 3.13/3.14 support bump ([#58](https://github.com/gdsfactory/gf180mcu/pull/58)).
+- Bump `actions/checkout` 5 → 6 ([#49](https://github.com/gdsfactory/gf180mcu/pull/49)).
+- Add code owners ([#55](https://github.com/gdsfactory/gf180mcu/pull/55)).
+- Install / pre-commit / release instructions in README ([#67](https://github.com/gdsfactory/gf180mcu/pull/67)).
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gf180mcu 0.5.0
+# gf180mcu 1.0.0
 
 <!-- BADGES:START -->
 [![Docs](https://github.com/gdsfactory/gf180mcu/actions/workflows/pages.yml/badge.svg)](https://github.com/gdsfactory/gf180mcu/actions/workflows/pages.yml)

--- a/gf180mcu/__init__.py
+++ b/gf180mcu/__init__.py
@@ -26,7 +26,7 @@ __all__ = [
     "layers",
     "logic",
 ]
-__version__ = "0.5.0"
+__version__ = "1.0.0"
 
 _cells = get_cells([cells, fixed, logic])
 

--- a/gf180mcu/klayout/grain.xml
+++ b/gf180mcu/klayout/grain.xml
@@ -3,7 +3,7 @@
  <name>gf180mcu</name>
  <token/>
  <hidden>false</hidden>
- <version>0.5.0</version>
+ <version>1.0.0</version>
  <api-version/>
  <title>gf180mcu</title>
  <doc>GlobalFoundries 180nm MCU primitive libraries</doc>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ license = {file = "LICENSE"}
 name = "gf180mcu"
 readme = "README.md"
 requires-python = ">=3.12,<3.15"
-version = "0.5.0"
+version = "1.0.0"
 
 [project.optional-dependencies]
 dev = [
@@ -127,7 +127,7 @@ message_template = "Bump to {new_version}"
 tag_template = "v{new_version}"
 
 [tool.tbump.version]
-current = "0.5.0"
+current = "1.0.0"
 regex = '''
   (?P<major>\d+)
   \.


### PR DESCRIPTION
## Summary

First stable release. Marks API parity with the upstream Magic Tcl pcell
generators and a stable public surface for downstream tools.

- Bumps version `0.5.0` → `1.0.0` across `pyproject.toml`, `gf180mcu/__init__.py`, `README.md`, `gf180mcu/klayout/grain.xml`.
- Replaces unreleased 0.5.0 CHANGELOG entry with a 1.0.0 entry consolidating draft v0.5.0 + #91 (Magic-parity pcell refactor) + recent infra (#94, #99, #103, #92, etc.).

## Why 1.0.0

The Magic-generator pcell port (#91) introduces a new logic surface and is the
trigger for committing to a stable API. Prior 0.x line carried no such guarantee.

## Test plan

- [ ] CI green on branch
- [ ] After merge: tag `v1.0.0` from main → release workflow publishes to PyPI
- [ ] Rename existing draft `v0.5.0` → `v1.0.0` (or recreate draft with merged notes) so `release.yml` can flip it to published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Cut a 1.0.0 stable release with updated changelog, version metadata, and release notes consolidating prior work.

New Features:
- Introduce VLSIR-based netlisting support.
- Add DRC workflows, metric badges, auto-label workflows, and README metrics dashboard.
- Tag all components with `@cell` type information and add missing pins.

Bug Fixes:
- Fix PDK activation in docs by using the Sphinx extension instead of importing the package directly.
- Hide private repository links from public documentation.
- Clarify LICENSE text and terms.

Enhancements:
- Refactor electrical parameterized cells to match upstream Magic Tcl generators and reorganize cell collections, including new diode variants.
- Adjust layer-stack overlaps and rework interdigitated cells for improved correctness and consistency.
- Centralize and streamline CI workflows and drift-enforced workflow templates.
- Update dependency constraints, including gdsfactory and GitHub Actions, and extend support to Python 3.13 and 3.14.
- Improve contributor guidance with README install, pre-commit, and release instructions and add CODEOWNERS for clearer ownership.

Build:
- Bump project version and tooling configuration from 0.5.0 to 1.0.0 across packaging metadata and KLayout grain file.
- Update release notes in CHANGELOG to describe the 1.0.0 stable release and consolidate prior unreleased changes.

CI:
- Add and update CI workflows for DRC, metrics badges, auto-labeling, and centralized workflow management.
- Sync and update shared GitHub workflow templates and Dependabot configuration, including the switch to the `uv` ecosystem and tuned update cadence.

Deployment:
- Align release metadata and workflows for publishing the 1.0.0 release to PyPI and associated tooling.

Documentation:
- Revise README to reflect 1.0.0 release and document installation, pre-commit, and release procedures.
- Clean up public documentation by removing links to private repositories.

Chores:
- Add CODEOWNERS to codify maintainership and review responsibility.