### PR TITLE
feat: add tool.elvis config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,14 @@ skip = "*.lock,*.svg,*.gds,*.oas,*.lib,*.tcl,scripts/magic/*,tests/test_componen
 [tool.gdsfactoryplus.pdk]
 name = "gf180mcu"
 
+
+[tool.elvis]
+short-layers = [[34, 0], [35, 0], [36, 0], [38, 0], [42, 0], [40, 0], [46, 0], [41, 0], [81, 0], [82, 0], [53, 0]]
+connected-layers = [[[34, 0], [36, 0]], [[36, 0], [42, 0]], [[42, 0], [46, 0]], [[46, 0], [81, 0]], [[81, 0], [53, 0]]]
+
+[tool.elvis.equivalent-ports]
+pad = ["e1", "e2", "e3", "e4", "pad"]
+
 [tool.mypy]
 python_version = "3.12"
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,16 +41,15 @@ tests = ["pytest", "pytest-cov"]
 ignore-words-list = "inout,ags,souce,te,hepl,deivces,accomodate"
 skip = "*.lock,*.svg,*.gds,*.oas,*.lib,*.tcl,scripts/magic/*,tests/test_components/test_pdk_settings_*.yml"
 
-[tool.gdsfactoryplus.pdk]
-name = "gf180mcu"
-
-
 [tool.elvis]
-short-layers = [[34, 0], [35, 0], [36, 0], [38, 0], [42, 0], [40, 0], [46, 0], [41, 0], [81, 0], [82, 0], [53, 0]]
 connected-layers = [[[34, 0], [36, 0]], [[36, 0], [42, 0]], [[42, 0], [46, 0]], [[46, 0], [81, 0]], [[81, 0], [53, 0]]]
+short-layers = [[34, 0], [35, 0], [36, 0], [38, 0], [42, 0], [40, 0], [46, 0], [41, 0], [81, 0], [82, 0], [53, 0]]
 
 [tool.elvis.equivalent-ports]
 pad = ["e1", "e2", "e3", "e4", "pad"]
+
+[tool.gdsfactoryplus.pdk]
+name = "gf180mcu"
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
## Summary
- Add `[tool.elvis]` section to `pyproject.toml` with `short-layers` and `connected-layers` derived from the PDK's tech.py connectivity definitions
- Add `[tool.elvis.equivalent-ports]` for pad cells where applicable

## Test plan
- [x] Verify layer tuples match the PDK's layer definitions
- [x] Verify connected-layers pairs are correct