### PR TITLE
fix [tool.elvis] connected-layers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ ignore-words-list = "inout,ags,souce,te,hepl,deivces,accomodate"
 skip = "*.lock,*.svg,*.gds,*.oas,*.lib,*.tcl,scripts/magic/*,tests/test_components/test_pdk_settings_*.yml"
 
 [tool.elvis]
-connected-layers = [[[34, 0], [36, 0]], [[36, 0], [42, 0]], [[42, 0], [46, 0]], [[46, 0], [81, 0]], [[81, 0], [53, 0]]]
+connected-layers = [[[34, 0], [35, 0]], [[35, 0], [36, 0]], [[36, 0], [38, 0]], [[38, 0], [42, 0]], [[42, 0], [40, 0]], [[40, 0], [46, 0]], [[46, 0], [41, 0]], [[41, 0], [81, 0]], [[81, 0], [82, 0]], [[82, 0], [53, 0]]]
 short-layers = [[34, 0], [35, 0], [36, 0], [38, 0], [42, 0], [40, 0], [46, 0], [41, 0], [81, 0], [82, 0], [53, 0]]
 
 [tool.elvis.equivalent-ports]


### PR DESCRIPTION
Routes connected-layers through via layers instead of jumping metal-to-metal directly. Fixes Gemini review on #109.