### PR TITLE
Add zensical docs support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ test-force: install
 cov:
 	uv run pytest --cov=gf180
 
-
 update:
 	pur
 
@@ -52,10 +51,16 @@ jupytext:
 notebooks:
 	jupytext docs/**/*.py --to ipynb
 
+docs-pdf:
+	cp CHANGELOG.md docs/changelog.md
+	uv run mkdocs build -f mkdocs-pdf.yml
 
 docs:
-	git submodule update --init --recursive
-	uv run --extra docs python docs/write_cells.py
-	uv run --extra docs jupyter-book build docs
+	cp CHANGELOG.md docs/changelog.md
+	uv run --extra docs zensical build
 
-.PHONY: drc doc docs
+docs-serve:
+	cp CHANGELOG.md docs/changelog.md
+	uv run --extra docs zensical serve -a localhost:8080
+
+.PHONY: drc drc-sample doc docs docs-pdf build

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,4 +1,3 @@
-# ruff: noqa: INP001
 """Post-process notebook markdown: convert MyST admonitions to Material style.
 
 Usage: python docs/hooks.py docs/notebooks/*.md

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,54 @@
+# ruff: noqa: INP001
+"""Post-process notebook markdown: convert MyST admonitions to Material style.
+
+Usage: python docs/hooks.py docs/notebooks/*.md
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def process(markdown: str) -> str:
+    """Apply all transformations to a markdown string."""
+    return _myst_to_material_admonitions(markdown)
+
+
+def _myst_to_material_admonitions(markdown: str) -> str:
+    r"""Convert MyST ```{type}\n...\n``` to Material !!! type\n\n    ..."""
+
+    def _replace(match: re.Match[str]) -> str:
+        kind = match.group(1)
+        body = match.group(2)
+        lines = body.splitlines()
+        title = ""
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        if lines and (m := re.match(r"^#+ +(.+)", lines[0])):
+            title = m.group(1)
+            lines.pop(0)
+        non_empty = [line for line in lines if line.strip()]
+        min_indent = min(
+            (len(line) - len(line.lstrip()) for line in non_empty), default=0
+        )
+        out = []
+        for line in lines:
+            if line.strip():
+                out.append("    " + line[min_indent:])
+            else:
+                out.append("")
+        header = f'!!! {kind} "{title}"' if title else f"!!! {kind}"
+        return header + "\n\n" + "\n".join(out).rstrip() + "\n"
+
+    return re.sub(
+        r"^```\{(\w+)\}\s*\n(.*?)^```\s*$",
+        _replace,
+        markdown,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+
+
+if __name__ == "__main__":
+    for path in sys.argv[1:]:
+        p = Path(path)
+        p.write_text(process(p.read_text()))

--- a/mkdocs-pdf.yml
+++ b/mkdocs-pdf.yml
@@ -1,0 +1,27 @@
+site_name: GlobalFoundries 180nm MCU
+docs_dir: docs
+site_dir: build/pdf
+nav:
+  - Home: index.md
+  - Reference:
+      - Changelog: changelog.md
+  - Tutorial:
+      - Overview: tutorial.md
+      - Migration: migration.md
+plugins:
+  - search
+  - autorefs
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_root_toc_entry: false
+            show_source: false
+  - with-pdf:
+      author: GDSFactory
+      cover_subtitle: Photonics Process Design Kit
+      output_path: ../../docs.pdf
+theme:
+  name: material
+  logo: logo.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,14 @@ dev = [
   "pytest-github-actions-annotate-failures",
   "towncrier"
 ]
-docs = ["jupytext", "matplotlib", "jupyter-book==1.0.3"]
+docs = [
+  "jupyter",
+  "mkdocs-material",
+  "mkdocs-with-pdf",
+  "nbconvert",
+  "mkdocstrings[python]>=0.27.0",
+  "zensical>=0.0.40,<0.1.0"
+]
 tests = ["pytest", "pytest-cov"]
 
 [tool.codespell]

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,31 @@
+[project]
+nav = [
+  {"Home" = "index.md"},
+  {"Reference" = [
+    {"Changelog" = "changelog.md"}
+  ]},
+  {"Tutorial" = [
+    {"Overview" = "tutorial.md"},
+    {"Migration" = "migration.md"}
+  ]}
+]
+site_dir = "docs/_build/html"
+site_name = "GlobalFoundries 180nm MCU"
+site_url = "https://gdsfactory.github.io/gf180mcu"
+
+[project.plugins.autorefs]
+
+[project.plugins.mkdocstrings]
+
+[project.plugins.mkdocstrings.handlers.python]
+
+[project.plugins.mkdocstrings.handlers.python.options]
+docstring_style = "google"
+show_root_toc_entry = false
+show_source = false
+
+[project.plugins.search]
+
+[project.theme]
+logo = "logo.png"
+name = "material"


### PR DESCRIPTION
## Summary
- Switch documentation to zensical (Material theme) with mkdocs-pdf support
- Update Makefile with `docs`, `docs-serve`, and `docs-pdf` targets

## Test plan
- [ ] `make docs` builds HTML documentation
- [ ] `make docs-pdf` generates PDF

## Summary by Sourcery

Switch project documentation to a Zensical/MkDocs-Material setup with HTML, PDF, and local-serve support, and add tooling to post-process notebook markdown admonitions.

New Features:
- Add Zensical/MkDocs-based documentation configuration for site navigation and theming.
- Introduce MkDocs PDF configuration to generate a Material-themed PDF manual from the docs.
- Add a hook script to convert MyST-style admonitions in notebook markdown to MkDocs Material admonitions.
- Add Makefile targets to build HTML docs, serve docs locally, and generate a PDF manual.

Enhancements:
- Update documentation dependency group to use MkDocs, Zensical, and related plugins instead of the previous Jupyter Book stack.

Build:
- Extend Makefile phony targets and commands to support the new documentation build and serve workflows.