### PR TITLE
Add S3 docs deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,3 +25,25 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+  deploy-s3:
+    needs: docs
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download pages artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: github-pages
+          path: artifact-tmp
+      - name: Extract docs
+        run: |
+          mkdir -p docs-html
+          tar -xf artifact-tmp/artifact.tar -C docs-html
+      - name: Deploy docs to S3
+        uses: doplaydo/infra/.github/actions/deploy-docs-s3@main
+        with:
+          docs-path: docs-html/
+          s3-prefix: gf180mcu/


### PR DESCRIPTION
## Summary\n- Add S3 deploy job to the docs workflow\n- Downloads the built pages artifact and deploys to S3 using `doplaydo/infra/.github/actions/deploy-docs-s3@main`\n- Only runs on push to main branch\n\n## Test plan\n- [ ] Verify the S3 deploy job runs after docs build on push to main\n

## Summary by Sourcery

Deployment:
- Introduce an S3 deployment job in the docs workflow that downloads the GitHub Pages artifact, extracts the built docs, and uploads them to S3 under the configured prefix.