### PR TITLE
Replace RST code directives with markdown code blocks

### DIFF
--- a/gf180mcu/tech.py
+++ b/gf180mcu/tech.py
@@ -23,11 +23,11 @@ def xsection(func: Callable[..., CrossSection]) -> Callable[..., CrossSection]:
 
     Ensures that the cross-section name matches the name of the function that generated it when created using default parameters
 
-    .. code-block:: python
-
+    ```python
         @xsection
         def strip(width=TECH.width_strip, radius=TECH.radius_strip):
             return gf.cross_section.cross_section(width=width, radius=radius)
+    ```
     """
     default_xs = func()
     _cross_section_default_names[default_xs.name] = func.__name__


### PR DESCRIPTION
## Summary

- Replace `.. code::` and `.. code-block:: python` RST directives with markdown triple-backtick code blocks in docstrings
- ASCII art diagrams and code examples were not rendering correctly with the new docs theme because it expects markdown, not RST

## Test plan

- [ ] Verify docs build correctly
- [ ] Check ASCII art diagrams render properly in the docs

## Summary by Sourcery

Documentation:
- Convert a Python code example in a docstring from RST code-block syntax to Markdown triple-backtick code fences for correct rendering with the new docs theme.