### PR TITLE
add update-changelog Makefile target

### DIFF
--- a/.github/workflows/code-security.yml
+++ b/.github/workflows/code-security.yml
@@ -1,0 +1,29 @@
+name: Code Security
+
+on:
+  pull_request:
+  merge_group:
+    branches: [main]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  sast:
+    uses: doplaydo/infra/.github/workflows/reuseable-sast.yaml@main
+    with:
+      output-format: text
+      fail-on-findings: false
+      enable-secrets-scan: true
+
+  sca:
+    uses: doplaydo/infra/.github/workflows/reuseable-sca.yaml@main
+    with:
+      scan-type: fs
+      scanners: misconfig,secret
+      fail-on-findings: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,7 @@ docs-serve:
 	cp CHANGELOG.md docs/changelog.md
 	uv run --extra docs zensical serve -f docs/zensical.toml -a localhost:8080
 
-.PHONY: drc drc-sample doc docs docs-pdf build
+update-changelog:
+	claude -p "remove links and make a user friendly changelog from @CHANGELOG.md to @docs/changelog.md"
+
+.PHONY: drc drc-sample doc docs docs-pdf build update-changelog


### PR DESCRIPTION
## Summary
- Add `update-changelog` Makefile target that uses Claude to generate a user-friendly changelog from CHANGELOG.md to docs/changelog.md

## Test plan
- [ ] Run `make update-changelog` to verify it works

## Summary by Sourcery

Add a Makefile target to generate a user-friendly changelog using Claude and introduce a Claude configuration file reference.

New Features:
- Introduce an update-changelog Makefile target to regenerate docs/changelog.md from CHANGELOG.md using Claude.

Enhancements:
- Add a CLAUDE.md file that references AGENTS.md for Claude-related configuration or context.