### PR TITLE
Convert cell docs to Markdown with kwasm viewers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,11 @@ docs-pdf: nbdocs sync-docs
 	uv run mkdocs build -f mkdocs-pdf.yml
 
 docs: nbdocs sync-docs
+	uv run python docs/write_cells.py
 	uv run --extra docs zensical build -f docs/zensical.toml
 
 docs-serve: nbdocs sync-docs
+	uv run python docs/write_cells.py
 	uv run --extra docs zensical serve -f docs/zensical.toml -a localhost:8080
 
 update-changelog:

--- a/docs/write_cells.py
+++ b/docs/write_cells.py
@@ -1,23 +1,29 @@
-"""Generate doc pages for all GF180MCU cells.
+"""Write cell docs as Markdown with kwasm viewers."""
 
-Writes:
-  docs/cells.rst       — PCells + Fixed
-  docs/logic_7t.rst    — 7-track 5V std cells (with plots)
-  docs/logic_9t.rst    — 9-track 5V std cells (with plots)
-"""
-
+import base64
 import inspect
 import pathlib
+import traceback
 
+import kwasm.embed
+import matplotlib
+import matplotlib.pyplot as plt
 from gdsfactory.serialization import clean_value_json
 
+matplotlib.use("Agg")
+
 from gf180mcu import PDK, logic
+from gf180mcu.config import PATH
+
+PDK.activate()
+cells = PDK.cells
 
 docs_dir = pathlib.Path(__file__).parent.absolute()
-filepath = docs_dir / "cells.rst"
-logic_7t_path = docs_dir / "logic_7t.rst"
-logic_9t_path = docs_dir / "logic_9t.rst"
-cells = PDK.cells
+filepath = docs_dir / "cells.md"
+logic_7t_path = docs_dir / "logic_7t.md"
+logic_9t_path = docs_dir / "logic_9t.md"
+kwasm_dir = docs_dir / "kwasm"
+gds_dir = kwasm_dir / "gds"
 
 skip = {
     "LIBRARY",
@@ -36,7 +42,54 @@ skip = {
 skip_plot: tuple[str, ...] = ("add_fiber_array_siepic",)
 skip_settings: tuple[str, ...] = ("flatten", "safe_cell_names")
 
-# Categorize cells
+
+def _setup_kwasm_viewer() -> None:
+    gds_dir.mkdir(parents=True, exist_ok=True)
+    viewer_path = kwasm_dir / "viewer.html"
+    if viewer_path.exists():
+        return
+    template = kwasm.embed._read_artifacts()
+    template = template.replace("KWASM_GDS_B64", "")
+    lyp_path = PATH.lyp
+    if lyp_path.exists():
+        lyp_b64 = base64.b64encode(lyp_path.read_bytes()).decode("ascii")
+        template = template.replace("KWASM_LYP_B64", lyp_b64)
+    else:
+        template = template.replace("KWASM_LYP_B64", "")
+    template = template.replace("KWASM_LYRDB_B64", "")
+    template = template.replace("KWASM_NETLIST_B64", "")
+    viewer_path.write_text(template)
+
+
+def _write_gds(name: str, cell_func) -> bool:
+    try:
+        sig = inspect.signature(cell_func)
+        defaults = {}
+        for p in sig.parameters:
+            v = sig.parameters[p].default
+            if isinstance(v, int | float | str | tuple):
+                defaults[p] = v
+        c = cell_func(**defaults)
+        c.write(str(gds_dir / f"{name}.gds"))
+        c.plot()
+        plt.savefig(str(gds_dir / f"{name}.png"), dpi=150, bbox_inches="tight")
+        plt.close("all")
+    except Exception:
+        traceback.print_exc()
+        plt.close("all")
+        return False
+    else:
+        return True
+
+
+def _module_for(name: str) -> str:
+    if "fd_sc_mcu7t5v0" in name or "fd_sc_mcu9t5v0" in name:
+        return "gf180mcu.logic"
+    if name in ("efuse",) or name.startswith("npn_") or name.startswith("pnp_"):
+        return "gf180mcu.fixed"
+    return "gf180mcu.cells"
+
+
 pcell_names = []
 fixed_names = []
 logic_7t_names = []
@@ -46,7 +99,7 @@ for name in sorted(cells.keys()):
     if name in skip or name.startswith("_"):
         continue
     if "fd_sc_mcu" in name:
-        continue  # std cells documented on dedicated logic_7t/9t pages
+        continue
     if name in ("efuse",) or name.startswith("npn_") or name.startswith("pnp_"):
         fixed_names.append(name)
     else:
@@ -61,24 +114,11 @@ for name in sorted(n for n in dir(logic) if not n.startswith("_")):
         logic_9t_names.append(name)
 
 
-def _module_for(name: str) -> str:
-    if "fd_sc_mcu7t5v0" in name or "fd_sc_mcu9t5v0" in name:
-        return "gf180mcu.logic"
-    if name in ("efuse",) or name.startswith("npn_") or name.startswith("pnp_"):
-        return "gf180mcu.fixed"
-    return "gf180mcu.cells"
-
+_setup_kwasm_viewer()
 
 with open(filepath, "w+") as f:
-    f.write(
-        """
-Cells
-=============================
-
-Parametric Cells (PCells)
------------------------------
-"""
-    )
+    f.write("# Cells\n\n")
+    f.write("## Parametric Cells (PCells)\n\n")
 
     for name in pcell_names:
         print(name)
@@ -92,71 +132,59 @@ Parametric Cells (PCells)
                 and p not in skip_settings
             ]
         )
-        f.write(
-            f"""
+        f.write(f"### {name}\n\n")
+        f.write(f"::: {mod}.{name}\n\n")
+        if name not in skip_plot:
+            has_gds = _write_gds(name, cells[name])
+            if has_gds:
+                f.write(f"![{name}](kwasm/gds/{name}.png)\n\n")
+                f.write(
+                    f'<iframe src="kwasm/viewer.html?url=gds/{name}.gds"'
+                    f' loading="lazy" width="100%" height="400"'
+                    f' style="border:none"></iframe>\n\n'
+                )
+            f.write("```python\n")
+            f.write("import gf180mcu\n\n")
+            f.write("gf180mcu.PDK.activate()\n")
+            f.write(f'c = gf180mcu._cells["{name}"]({kwargs})\n')
+            f.write("c.draw_ports()\n")
+            f.write("c.plot()\n")
+            f.write("```\n\n")
 
-{name}
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. autofunction:: {mod}.{name}
-
-.. plot::
-  :include-source:
-
-  import gf180mcu
-
-  c = gf180mcu._cells["{name}"]({kwargs})
-  c = c.copy()
-  c.draw_ports()
-  c.plot()
-
-"""
-        )
-
-    f.write(
-        """
-
-Fixed Cells (BJT, eFuse)
------------------------------
-"""
-    )
+    f.write("## Fixed Cells (BJT, eFuse)\n\n")
 
     for name in fixed_names:
         print(name)
         mod = _module_for(name)
-        f.write(
-            f"""
+        f.write(f"### {name}\n\n")
+        f.write(f"::: {mod}.{name}\n\n")
 
-{name}
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. autofunction:: {mod}.{name}
-
-"""
-        )
+print(f"Wrote {filepath}")
 
 
 def _write_logic_page(path: pathlib.Path, title: str, names: list[str]) -> None:
     with open(path, "w+") as f:
-        underline = "=" * len(title)
-        f.write(f"{title}\n{underline}\n\n")
+        f.write(f"# {title}\n\n")
         for name in names:
             print(name)
-            f.write(
-                f"""
-{name}
-{"^" * len(name)}
-
-.. autofunction:: gf180mcu.logic.{name}
-
-.. plot::
-
-   from gf180mcu import PDK, logic
-   PDK.activate()
-   logic.{name}().plot()
-
-"""
-            )
+            func = getattr(logic, name)
+            f.write(f"## {name}\n\n")
+            f.write(f"::: gf180mcu.logic.{name}\n\n")
+            has_gds = _write_gds(name, func)
+            if has_gds:
+                f.write(f"![{name}](kwasm/gds/{name}.png)\n\n")
+                f.write(
+                    f'<iframe src="kwasm/viewer.html?url=gds/{name}.gds"'
+                    f' loading="lazy" width="100%" height="400"'
+                    f' style="border:none"></iframe>\n\n'
+                )
+            f.write("```python\n")
+            f.write("from gf180mcu import PDK, logic\n\n")
+            f.write("PDK.activate()\n")
+            f.write(f"c = logic.{name}()\n")
+            f.write("c.plot()\n")
+            f.write("```\n\n")
+    print(f"Wrote {path}")
 
 
 _write_logic_page(

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -3,6 +3,9 @@ docs_dir = "."
 nav = [
   {"Home" = "index.md"},
   {"Reference" = [
+    {"Cells" = "cells.md"},
+    {"Logic 7T" = "logic_7t.md"},
+    {"Logic 9T" = "logic_9t.md"},
     {"Changelog" = "changelog.md"}
   ]},
   {"Tutorial" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
 ]
 docs = [
   "jupyter",
+  "kwasm",
   "mkdocs-material",
   "mkdocs-with-pdf",
   "nbconvert",


### PR DESCRIPTION
## Summary
- Rewrote `docs/write_cells.py` to generate Markdown (`.md`) instead of RST (`.rst`), matching the pattern used in [HHI](https://github.com/doplaydo/hhi)
- Uses mkdocstrings autodoc syntax (`::: gf180mcu.cells.{name}`) and kwasm interactive GDS viewers with PNG fallback images
- Added cells, logic_7t, and logic_9t pages to `zensical.toml` nav
- Wired up `write_cells.py` in the Makefile `docs` and `docs-serve` targets

The previous `write_cells.py` generated RST files, but the docs build uses zensical (mkdocs-based) which expects Markdown — so cells were never rendered in the docs.

## Test plan
- [ ] Verify `make docs` builds successfully and cells appear in the generated site
- [ ] Check kwasm interactive viewers load correctly for each cell
- [ ] Confirm logic_7t and logic_9t pages render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Convert GF180MCU cell documentation generation from RST to Markdown and integrate interactive kwasm GDS viewers into the docs build.

New Features:
- Generate Markdown documentation pages for cells, logic_7t, and logic_9t using mkdocstrings syntax.
- Embed kwasm-based interactive GDS viewers with PNG fallbacks for cells and logic standard-cell pages.

Enhancements:
- Automatically create GDS and PNG artifacts for each documented cell during docs generation.
- Activate the PDK and categorize cells consistently for use across the new Markdown pages.
- Expose example Python usage snippets alongside each documented cell in the generated docs.

Build:
- Hook write_cells.py into the docs and docs-serve Makefile targets so the Markdown cell pages are regenerated on each docs build.

Documentation:
- Add cells.md, logic_7t.md, and logic_9t.md to the Zensical (mkdocs) navigation to surface the new cell documentation pages.