### PR TITLE
Add Static/Dynamic tabs for docs layout viewers

### DIFF
--- a/docs/write_cells.py
+++ b/docs/write_cells.py
@@ -137,9 +137,11 @@ with open(filepath, "w+") as f:
         if name not in skip_plot:
             has_gds = _write_gds(name, cells[name])
             if has_gds:
-                f.write(f"![{name}](kwasm/gds/{name}.png)\n\n")
+                f.write('=== "Static"\n\n')
+                f.write(f"    ![{name}](kwasm/gds/{name}.png)\n\n")
+                f.write('=== "Dynamic"\n\n')
                 f.write(
-                    f'<iframe src="kwasm/viewer.html?url=gds/{name}.gds"'
+                    f'    <iframe src="kwasm/viewer.html?url=gds/{name}.gds"'
                     f' loading="lazy" width="100%" height="400"'
                     f' style="border:none"></iframe>\n\n'
                 )
@@ -172,9 +174,11 @@ def _write_logic_page(path: pathlib.Path, title: str, names: list[str]) -> None:
             f.write(f"::: gf180mcu.logic.{name}\n\n")
             has_gds = _write_gds(name, func)
             if has_gds:
-                f.write(f"![{name}](kwasm/gds/{name}.png)\n\n")
+                f.write('=== "Static"\n\n')
+                f.write(f"    ![{name}](kwasm/gds/{name}.png)\n\n")
+                f.write('=== "Dynamic"\n\n')
                 f.write(
-                    f'<iframe src="kwasm/viewer.html?url=gds/{name}.gds"'
+                    f'    <iframe src="kwasm/viewer.html?url=gds/{name}.gds"'
                     f' loading="lazy" width="100%" height="400"'
                     f' style="border:none"></iframe>\n\n'
                 )


### PR DESCRIPTION
Fixes #132

## Summary

- Each layout viewer in the generated docs now renders as two tabs: **Static** (PNG image, default) and **Dynamic** (interactive kwasm viewer)
- Modified file: docs/write_cells.py

## Test plan

- [ ] Run docs build and verify cells page renders with Static/Dynamic tabs
- [ ] Confirm tab switching works between Static and Dynamic views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add tabbed Static/Dynamic layout viewers to the generated docs for cells and logic pages.

New Features:
- Render each cell layout image alongside an interactive viewer using Static and Dynamic tabs in the docs.

Enhancements:
- Adjust docs layout markup and indentation to integrate tabbed content for layout viewers.