### PR TITLE
Add --verbose flag to twine upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           make build
-          twine upload dist/*
+          twine upload --verbose dist/*
   release_environment:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `--verbose` flag to twine upload commands in the release workflow for better upload diagnostics.

Closes #135

## Test plan
- [ ] Trigger a release workflow run and verify twine outputs verbose logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Enable verbose mode for twine uploads in the release GitHub Actions workflow.