### PR TITLE
fix: correct pre-commit instructions and add tests section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,18 @@ uv sync --extra docs --extra dev
 
 ## Pre-commit
 
+Pre-commit hooks are centrally maintained in [pdk-ci-workflow](https://github.com/doplaydo/pdk-ci-workflow). `make dev` fetches the canonical config and installs the git hook.
+
 ```bash
-make pre-commit
+make dev
+```
+
+## Tests
+
+Run the test suite:
+
+```bash
+make test
 ```
 
 ## Release

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ uv sync --extra docs --extra dev
 
 ## Pre-commit
 
-Pre-commit hooks are centrally maintained in [pdk-ci-workflow](https://github.com/doplaydo/pdk-ci-workflow). `make dev` fetches the canonical config and installs the git hook.
+Pre-commit hooks are centrally maintained in [pdk-ci-workflow-public](https://github.com/doplaydo/pdk-ci-workflow-public). `make dev` fetches the canonical config and installs the git hook.
 
 ```bash
 make dev

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gf180mcu 1.0.0
 
+GlobalFoundries' 180nm MCU process, a fully open-source CMOS technology (built on Google's open PDK initiative) for mixed-signal and analog IC design.
+
 <!-- BADGES:START -->
 [![Docs](https://github.com/gdsfactory/gf180mcu/actions/workflows/pages.yml/badge.svg)](https://github.com/gdsfactory/gf180mcu/actions/workflows/pages.yml)
 [![Tests](https://github.com/gdsfactory/gf180mcu/actions/workflows/test_code.yml/badge.svg)](https://github.com/gdsfactory/gf180mcu/actions/workflows/test_code.yml)


### PR DESCRIPTION
The Makefile's pre-commit setup target is `dev` (fetches the canonical config from pdk-ci-workflow), not `make pre-commit`. This updates the README to match, and adds a missing `## Tests` section documenting `make test`.

Part of doplaydo/pdks#49.

## Summary by Sourcery

Update README to document the correct pre-commit setup command and add a tests section describing how to run the test suite.

Documentation:
- Clarify pre-commit hook setup in README to use the `make dev` target and reference the central pdk-ci-workflow configuration.
- Add a README tests section documenting running the test suite with `make test`.