### PR TITLE
test: check all ports have manhattan orientations

### DIFF
--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -70,3 +70,25 @@ def test_optical_port_positions(component_name: str) -> None:
                 raise AssertionError(
                     f"Port {port.name} has width {port_width}, but the optical edge length is {edge_length}."
                 )
+
+
+MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
+
+skip_test_manhattan_ports: set[str] = set()
+
+
+@pytest.mark.parametrize("component_name", cell_names)
+def test_port_orientations_manhattan(component_name: str) -> None:
+    """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
+    if component_name in skip_test_manhattan_ports:
+        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
+    component = cells[component_name]()
+    if isinstance(component, gf.ComponentAllAngle):
+        pytest.skip(f"{component_name} is an all-angle component")
+    for port in component.ports:
+        orientation = port.orientation % 360
+        if not np.any(np.isclose(orientation, MANHATTAN_ORIENTATIONS, atol=1e-3)):
+            raise AssertionError(
+                f"Port {port.name} of {component_name} has non-manhattan "
+                f"orientation {port.orientation} degrees."
+            )


### PR DESCRIPTION
Closes #160

Adds `test_port_orientations_manhattan` to `tests/test_components.py`, parametrized over every PDK cell. For each cell it builds the component and asserts that every port's orientation is 0, 90, 180 or 270 degrees (modulo 360, with a 1e-3 tolerance). All-angle components (`gf.ComponentAllAngle`) are skipped, and a `skip_test_manhattan_ports` set is available for known issues.

This is a templated rollout of the same test we are adding across our PDKs; the pattern has already been reviewed and merged elsewhere.

⚠️ AI-created PR: a human must review the actual code changes before merge.

## Test plan

- [ ] CI passes

## Summary by Sourcery

Tests:
- Add a parametrized test that asserts all ports in each PDK cell have manhattan orientations, skipping known all-angle or explicitly skipped components.