### PR TITLE
docs: document missing arguments in cells and klayout pcells

### DIFF
--- a/gf180mcu/cells/res.py
+++ b/gf180mcu/cells/res.py
@@ -435,7 +435,8 @@ def _draw_end_contact(
 
     Args:
         c: component
-        cx, cy: center position
+        cx: contact center x position in um
+        cy: contact center y position in um
         fill_w: contact fill width (cpl)
         end_layer: base layer (poly2 or comp)
         orient: "horz" or "vert" for metal growth direction

--- a/gf180mcu/cells/via_generator.py
+++ b/gf180mcu/cells/via_generator.py
@@ -111,6 +111,8 @@ def via_stack(
         via_size: via size.
         via_spacing: via spacing.
         via_enc: via enclosure.
+        base_layer: layer drawn around the bottom contacts, i.e. the first
+            metal of the stack.
 
 
     return via stack till the metal level indicated where :

--- a/klayout/pymacros/cells/draw_cap_mim.py
+++ b/klayout/pymacros/cells/draw_cap_mim.py
@@ -18,8 +18,15 @@ def draw_cap_mim(
 
     Args:
         layout : layout object
+        mim_option : string of the mim flavor ("MIM-B" uses the upper metal
+            stack, anything else uses metal2/metal3)
+        metal_level : string of the top metal of the MIM-B stack
+            ("M4", "M5" or "M6")
         lc : float of cap length
         wc : float of cap width
+        label : boolean of having labels
+        top_label : string of the top plate label
+        bot_label : string of the bottom plate label
 
 
     """

--- a/klayout/pymacros/cells/draw_fet.py
+++ b/klayout/pymacros/cells/draw_fet.py
@@ -1266,17 +1266,27 @@ def draw_nfet(
 
     Args:
         layout : layout object
-        l : Float of gate length
-        w : Float of gate width
-        sd_l : Float of source and drain diffusion length
+        l_gate : Float of gate length in um
+        w_gate : Float of gate width in um
+        sd_con_col : integer of number of contact columns in the source and
+            drain diffusion, it sets the diffusion length
         inter_sd_l : Float of source and drain diffusion length between fingers
         nf : integer of number of fingers
-        M : integer of number of multipliers
         grw : guard ring width when enabled
-        type : string of the device type
+        volt : string of the operating voltage (3.3V, 5V, 6V), 5V/6V adds the
+            dualgate layer and uses wider spacings
         bulk : String of bulk connection type (None, Bulk Tie, Guard Ring)
         con_bet_fin : boolean of having contacts for diffusion between fingers
         gate_con_pos : string of choosing the gate contact position (bottom, top, alternating )
+        interdig : boolean of having interdigitated fingers
+        patt : string of the required interdigitation pattern
+        deepnwell : boolean of having deepnwell
+        pcmpgr : boolean of having deepnwell guardring
+        label : boolean of having labels
+        sd_label : list of source and drain labels
+        g_label : list of gate labels
+        sub_label : string of the substrate/bulk label
+        patt_label : boolean of labelling the interdigitation pattern
 
     """
     # used layers and dimensions
@@ -1883,17 +1893,27 @@ def draw_pfet(
 
     Args:
         layout : layout object
-        l : Float of gate length
-        w : Float of gate width
-        sd_l : Float of source and drain diffusion length
+        l_gate : Float of gate length in um
+        w_gate : Float of gate width in um
+        sd_con_col : integer of number of contact columns in the source and
+            drain diffusion, it sets the diffusion length
         inter_sd_l : Float of source and drain diffusion length between fingers
         nf : integer of number of fingers
-        M : integer of number of multipliers
         grw : guard ring width when enabled
-        type : string of the device type
+        volt : string of the operating voltage (3.3V, 5V, 6V), 5V/6V adds the
+            dualgate layer and uses wider spacings
         bulk : String of bulk connection type (None, Bulk Tie, Guard Ring)
         con_bet_fin : boolean of having contacts for diffusion between fingers
         gate_con_pos : string of choosing the gate contact position (bottom, top, alternating )
+        interdig : boolean of having interdigitated fingers
+        patt : string of the required interdigitation pattern
+        deepnwell : boolean of having deepnwell
+        pcmpgr : boolean of having deepnwell guardring
+        label : boolean of having labels
+        sd_label : list of source and drain labels
+        g_label : list of gate labels
+        sub_label : string of the substrate/bulk label
+        patt_label : boolean of labelling the interdigitation pattern
 
     """
     # used layers and dimensions


### PR DESCRIPTION
Closes #162

The shared pre-commit config now runs `pydocstyle --select=D417`, which requires every positional and keyword-only argument to have an entry in the docstring `Args:` / `Parameters` section.

- `_draw_end_contact`: split the combined `cx, cy` entry, which pydocstyle does not recognise as documenting either name
- `via_stack`: `base_layer`
- `draw_cap_mim`: `mim_option`, `metal_level`, `label`, `top_label`, `bot_label`
- `draw_nfet` / `draw_pfet`: 13 arguments each. These docstrings still described an older signature — `l`, `w` and `sd_l` are now `l_gate`, `w_gate` and `sd_con_col`, and `M` and `type` no longer exist. Replaced the stale entries and reordered to match the signature.

Descriptions reuse the wording of sibling functions in the same files where one already documents the same argument.

Docstrings only; no behavior change.

## Test plan
- [ ] CI pre-commit job passes

---
Requested by @joamatab. AI-authored — please review the wording of the new argument descriptions before merging.

## Summary by Sourcery

Document all previously missing or outdated cell and KLayout PCell function arguments without changing behavior.

Enhancements:
- Complete cell and KLayout PCell docstrings with accurate documentation for all positional and keyword-only arguments, including updated FET signatures.

Documentation:
- Update argument documentation for resistor, via, MIM capacitor, and NFET/PFET cell-generation functions to satisfy pydocstyle D417.